### PR TITLE
Persist settings with zustand local storage

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -45,6 +45,7 @@ turbo.json                # Turborepo pipeline
 - Keep Tailwind class strings readable; compute long `className` strings outside `return`.
 - Don’t do drive-by refactors unrelated to the goal.
 - Keep file names short and descriptive.
+- File names should start with a segment indicating their purpose (e.g. `List.tsx`, `ListSorting.tsx`, `ListSortingBtn.tsx`...).
 
 ## Constants and helpers
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,122 @@
+# Copilot instructions (hardy)
+
+Use these instructions for every change in this repo.
+
+## What this repo is
+
+- Turborepo monorepo.
+- Main app: `apps/web` (Next.js App Router).
+- Shared packages: `packages/*`.
+- Styling: TailwindCSS (custom palette + Iconify plugin).
+- State: Zustand (store/actions/selectors pattern).
+- Next.js config: `apps/web/next.config.js` uses `output: "export"` (static export).
+
+## Project structure
+
+```text
+apps/                     # runnable applications
+  web/                    # main Next.js app (Next.js App Router)
+    app/                  # App Router routes + most UI
+      components/         # shared UI components (Modal, Button, tables, etc.)
+      constants/          # shared constants (defaults, limits, labels)
+      helpers/            # shared pure helpers (parsing/formatting/sorting)
+      plugins/            # app-specific plugins
+      providers/          # React providers (context/setup)
+      store/              # Zustand store (state/actions/selectors)
+  docs/                   # docs app (also Next.js)
+    app/
+
+packages/                 # shared workspace packages
+  ui/                     # shared UI package
+  eslint-config/          # shared ESLint configs
+  typescript-config/      # shared TS configs
+
+_stuff/                   # local artifacts (e.g. HAR files); don’t import from here
+
+package.json              # workspace scripts + dependency versions
+turbo.json                # Turborepo pipeline
+```
+
+## Coding conventions
+
+- Prefer TypeScript with strong typing at component boundaries.
+- Keep components small; extract reusable UI into `apps/web/app/components/`.
+- Avoid one-letter variable names (except trivial loops).
+- Keep Tailwind class strings readable; compute long `className` strings outside `return`.
+- Don’t do drive-by refactors unrelated to the goal.
+- Keep file names short and descriptive.
+
+## Constants and helpers
+
+- Colocate helpers/constants next to a component first; extract only when shared.
+- Use these shared locations under `apps/web/app/` when appropriate:
+  - `constants/` for defaults/limits/labels.
+  - `helpers/` for pure functions (parsing/formatting/sorting).
+- Don’t create extra `*.types.ts` / `*.constants.ts` files for a single component. Keep small local types/constants in the component file unless they’re reused across multiple modules.
+- Keep helpers pure (no store access, no `window`) unless explicitly browser-only.
+- Avoid “god utils” files; export small, testable functions.
+
+## State management (Zustand)
+
+- Prefer existing actions/selectors patterns.
+- Don’t mix unrelated concerns in the same state object.
+- If persisting to localStorage, keep defaults exported (e.g. `initialSettings`) so reset-to-default is easy.
+
+### Store structure (apps/web/app/store)
+
+- Source of truth is `apps/web/app/store/store.ts`:
+  - Exports types (`AppState`, `Ui`, `UiPersistent`, `Filter`, `Sorting`, `Settings`, …).
+  - Exports initial/default objects (`initialUiState`, `initialUiPersistentState`, `initialFilterState`, `initialSortingState`, `initialSettings`, …).
+  - Creates the hook: `useAppStore = create<AppState>()(persist(...))`.
+- Persistence:
+  - Only persist _small UI preferences_ (currently `uiPersistent` + `settings`) via `partialize`.
+  - Keep persisted merge logic inside `store.ts` (`merge`) and keep it backward-compatible (defaults first, then persisted overlay).
+
+### Actions
+
+- Put mutations in `apps/web/app/store/actions.ts`.
+- Pattern used here: `useAppStore.setState((state) => ({ ... }))` with immutable updates.
+  - For nested fields, spread the parent object: `uiPersistent: { ...state.uiPersistent, sortingActive }`.
+  - For `Set` updates (e.g. `pinnedIds`), always clone first: `const pinnedIds = new Set(state.ui.pinnedIds)`.
+- Keep actions small and named as verbs:
+  - `setFilterActive`, `setSortingActive`, `clearSorting`, `togglePinnedRow`, etc.
+- Keep cross-cutting state separate (this repo already splits `filter` vs `sorting` vs `uiPersistent`).
+
+### Selectors
+
+- Put getters in `apps/web/app/store/selectors.ts`.
+- Keep selectors pure and predictable:
+  - Simple selectors return a field (`selectSorting = (state) => state.sorting`).
+  - Derived selectors can compose other selectors (`selectFileSize` uses `selectFiles` + `selectFileId`).
+  - Be defensive with optional HAR data (`?.`) and array checks.
+- Prefer descriptive names with `select*` prefix.
+
+## React component best practices
+
+- Function components + hooks.
+- Avoid `useEffect` unless syncing with the outside world; always clean up.
+- Don’t store derived values in state; compute them or memoize if expensive.
+- Stable list keys (IDs), not array indexes.
+- Accessibility: semantic elements, keyboard support, focus styles.
+- Next.js App Router:
+  - Add `"use client"` only when needed.
+  - Server components must not reference client-only APIs (`window`, Zustand store, etc.).
+
+## UI guidelines
+
+- Modals use the shared `Modal` component (built on `<dialog>`): Escape/backdrop close, size variants, scrollable body + fixed footer.
+- For creating buttons, use the shared `Button` component for consistent variants/sizes.
+
+## Dark mode
+
+- Verify UI in light + dark mode.
+- Use Tailwind `dark:` variants.
+- Avoid hardcoding light-only colors without a dark counterpart.
+- Ensure hover/focus/disabled states look correct in both themes.
+
+## Quality gates (prefer before finishing)
+
+- Typecheck (TS)
+- Lint
+- Tests (if configured)
+- Small smoke check of the web app

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,7 @@
     "curlybraces",
     "iconify",
     "pageref",
+    "partialize",
     "tailwindcss",
     "zustand"
   ]

--- a/apps/web/app/components/ActionIcon.tsx
+++ b/apps/web/app/components/ActionIcon.tsx
@@ -3,10 +3,12 @@ import React from "react";
 export function ActionIcon({
   onClick,
   active,
+  disabled,
   icon,
 }: {
   onClick?: () => void;
   active?: boolean;
+  disabled?: boolean;
   icon?: string;
 }) {
   const base = "hover:text-accent-600 my-auto text-xl";
@@ -15,14 +17,16 @@ export function ActionIcon({
     ? "dark:text-accent-500 dark:hover:text-accent-300"
     : "dark:bg-slate-400 dark:hover:bg-slate-300";
 
+  const disabledClasses = disabled ? "opacity-50 pointer-events-none" : "";
+
   const handleClick = () => onClick?.();
 
   return (
     <div
       role="button"
       tabIndex={0}
-      onClick={handleClick}
-      className={`${stateClasses} ${base} ${icon ?? ""}`}
+      onClick={disabled ? undefined : handleClick}
+      className={`${stateClasses} ${base} ${disabledClasses} ${icon ?? ""}`}
     />
   );
 }

--- a/apps/web/app/components/ActionIcon.tsx
+++ b/apps/web/app/components/ActionIcon.tsx
@@ -11,11 +11,11 @@ export function ActionIcon({
   disabled?: boolean;
   icon?: string;
 }) {
-  const base = "hover:text-accent-600 my-auto text-xl";
+  const base = "my-auto text-xl";
 
   const stateClasses = active
-    ? "dark:text-accent-500 dark:hover:text-accent-300"
-    : "dark:bg-slate-400 dark:hover:bg-slate-300";
+    ? "text-accent-300 hover:text-accent-100 dark:text-accent-500 dark:hover:text-accent-300"
+    : "text-slate-300 hover:text-white dark:bg-slate-400 dark:hover:bg-slate-300";
 
   const disabledClasses = disabled ? "opacity-50 pointer-events-none" : "";
 

--- a/apps/web/app/components/ActionText.tsx
+++ b/apps/web/app/components/ActionText.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 export function ActionText({ children }: { children: React.ReactNode }) {
   return (
-    <span className="mt-0.5 text-sm uppercase dark:text-slate-500">
+    <span className="mt-0.5 text-sm uppercase text-slate-500 dark:text-slate-500">
       {children}
     </span>
   );

--- a/apps/web/app/components/AppHeaderActions.tsx
+++ b/apps/web/app/components/AppHeaderActions.tsx
@@ -4,15 +4,19 @@ import {
   selectDetailFormatterId,
   selectFiles,
   selectFilterActive,
+  selectPinnedIds,
   selectShowPages,
+  selectShowPinnedOnly,
   selectSortingActive,
 } from "../store/selectors";
 import {
+  clearAllPinned,
   clearFilter,
   clearSorting,
   setDetailFormatter,
   setFilterActive,
   setShowPages,
+  setShowPinnedOnly,
   setSortingActive,
 } from "../store/actions";
 import { ActionBar } from "./ActionBar";
@@ -30,7 +34,11 @@ export function AppHeaderActions(): JSX.Element {
   const filterActive = useAppStore(selectFilterActive);
   const sortingActive = useAppStore(selectSortingActive);
   const showPages = useAppStore(selectShowPages);
+  const showPinnedOnly = useAppStore(selectShowPinnedOnly);
+  const pinnedIds = useAppStore(selectPinnedIds);
   const detailFormatterId = useAppStore(selectDetailFormatterId);
+
+  const isPinnedEmpty = pinnedIds.size === 0;
 
   const handleFilterActive = () => {
     setFilterActive(!filterActive);
@@ -44,6 +52,14 @@ export function AppHeaderActions(): JSX.Element {
 
   const handleShowPages = () => {
     setShowPages(!showPages);
+  };
+
+  const handleShowPinnedOnly = () => {
+    setShowPinnedOnly(!showPinnedOnly);
+  };
+
+  const handleClearPinned = () => {
+    clearAllPinned();
   };
 
   return (
@@ -82,6 +98,23 @@ export function AppHeaderActions(): JSX.Element {
             onClick={handleShowPages}
             active={showPages}
             icon="iconify material-symbols--note-stack-outline"
+          />
+
+          <ActionIcon
+            onClick={handleShowPinnedOnly}
+            active={showPinnedOnly}
+            disabled={isPinnedEmpty}
+            icon={
+              isPinnedEmpty
+                ? `iconify material-symbols--bookmarks-outline`
+                : `iconify material-symbols--bookmarks-rounded`
+            }
+          />
+
+          <ActionIcon
+            onClick={handleClearPinned}
+            disabled={isPinnedEmpty}
+            icon="iconify material-symbols--bookmark-remove-outline-rounded"
           />
 
           <ActionSeparator type="line" />

--- a/apps/web/app/components/AppHeaderActions.tsx
+++ b/apps/web/app/components/AppHeaderActions.tsx
@@ -4,7 +4,7 @@ import {
   selectDetailFormatterId,
   selectFiles,
   selectFilterActive,
-  selectSettings,
+  selectShowPages,
   selectSortingActive,
 } from "../store/selectors";
 import {
@@ -29,7 +29,7 @@ export function AppHeaderActions(): JSX.Element {
   const files = useAppStore(selectFiles);
   const filterActive = useAppStore(selectFilterActive);
   const sortingActive = useAppStore(selectSortingActive);
-  const { showPages } = useAppStore(selectSettings);
+  const showPages = useAppStore(selectShowPages);
   const detailFormatterId = useAppStore(selectDetailFormatterId);
 
   const handleFilterActive = () => {

--- a/apps/web/app/components/Button.tsx
+++ b/apps/web/app/components/Button.tsx
@@ -49,11 +49,11 @@ export default function Button({
       "dark:hover:text-white bg-mirage-50 text-mirage-700 hover:bg-mirage-100 dark:text-mirage-100 dark:bg-slate-700 dark:hover:bg-slate-600",
     ghost:
       "dark:hover:text-white bg-transparent text-mirage-700 hover:bg-mirage-100 dark:text-mirage-100 dark:hover:bg-slate-700",
-    flat: "dark:hover:text-white bg-transparent text-white dark:text-mirage-100",
+    flat: "dark:hover:text-white bg-transparent text-black dark:text-mirage-100",
   };
 
   const disabledClasses = disabled
-    ? "opacity-60 cursor-not-allowed pointer-events-none"
+    ? "opacity-60 cursor-default pointer-events-none"
     : "cursor-pointer";
 
   const iconSizeMap: Record<Size, string> = {

--- a/apps/web/app/components/Collapsible.tsx
+++ b/apps/web/app/components/Collapsible.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { ToggleMark } from "./ToggleMark";
-import { Formatter, ContentValue } from "../providers/contentValueFormatter";
+import { Formatter } from "../providers/Formatter";
 
 export function Collapsible({
   children,

--- a/apps/web/app/components/Collapsible.tsx
+++ b/apps/web/app/components/Collapsible.tsx
@@ -55,7 +55,7 @@ export function Collapsible({
         </div>
       ) : (
         <div
-          className={`${sticky ? "sticky top-0 z-10 drop-shadow-lg" : ""} dark:bg-bunker-950 group flex bg-white`}
+          className={`${sticky ? "sticky top-0 z-10" : ""} dark:bg-bunker-950 group flex bg-white`}
         >
           <div
             className={`${disabledClasses} ${transparent ? "bg-transparent" : "bg-mirage-50 dark:bg-bunker-500"} text-mirage-700 dark:text-mirage-300 flex flex-1 select-none justify-start gap-2 rounded-md p-3 py-1.5 pl-2 transition-colors duration-200`}

--- a/apps/web/app/components/DetailCommon.tsx
+++ b/apps/web/app/components/DetailCommon.tsx
@@ -8,6 +8,7 @@ import { Status } from "./Status";
 import { Time } from "./Time";
 import { DetailField } from "./DetailField";
 import { LineClamp } from "./LineClamp";
+import UrlDetailsModal from "./UrlDetailsModal";
 
 export function DetailCommon(): JSX.Element | null {
   const data = useAppStore(selectCommonData);
@@ -21,14 +22,21 @@ export function DetailCommon(): JSX.Element | null {
 
   return (
     <div className="bg-mirage-50 dark:bg-bunker-500 flex flex-1 flex-col gap-1 rounded-md p-2">
-      <LineClamp
-        active={url.length > 100}
-        classes={"dark:bg-bunker-500 bg-mirage-50"}
-      >
-        <DetailField label={"URL:"}>
-          <Url url={url} />
-        </DetailField>
-      </LineClamp>
+      <div className="flex gap-2">
+        <div className="flex-1">
+          <LineClamp
+            active={url.length > 100}
+            classes={"dark:bg-bunker-500 bg-mirage-50"}
+          >
+            <DetailField label={"URL:"}>
+              <Url url={url} />
+            </DetailField>
+          </LineClamp>
+        </div>
+        <div>
+          <UrlDetailsModal url={url} />
+        </div>
+      </div>
 
       <hr className="border-mirage-100 dark:border-bunker-700 my-1 border border-b" />
 

--- a/apps/web/app/components/FileContent.tsx
+++ b/apps/web/app/components/FileContent.tsx
@@ -11,6 +11,7 @@ import { Panel } from "./Panel";
 import { ListFilter } from "./ListFilter";
 import { ListSorting } from "./ListSorting";
 import { detailFormatters } from "../providers/detailFormatter";
+import SplitPanels from "./SplitPanels";
 
 export function FileContent(): JSX.Element {
   const filterActive = useAppStore(selectFilterActive);
@@ -24,14 +25,23 @@ export function FileContent(): JSX.Element {
 
   const DetailView = formatFn ? formatFn(entry) : null;
 
+  const leftPanel = (
+    <Panel>
+      {filterActive && <ListFilter />}
+      {sortingActive && <ListSorting />}
+      <List />
+    </Panel>
+  );
+
+  const rightPanel = <Panel>{DetailView}</Panel>;
+
   return (
-    <main className="flex flex-1 flex-col items-stretch overflow-hidden lg:flex-row">
-      <Panel>
-        {filterActive && <ListFilter />}
-        {sortingActive && <ListSorting />}
-        <List />
-      </Panel>
-      <Panel>{DetailView}</Panel>
+    <main className="flex flex-1 items-stretch overflow-hidden">
+      <SplitPanels
+        left={leftPanel}
+        right={rightPanel}
+        initialLeftPercent={50}
+      />
     </main>
   );
 }

--- a/apps/web/app/components/FileTab.tsx
+++ b/apps/web/app/components/FileTab.tsx
@@ -1,4 +1,4 @@
-import { clearFilter, removeFile } from "../store/actions";
+import { clearAllPinned, clearFilter, removeFile } from "../store/actions";
 
 interface FileTabProps {
   file: {
@@ -13,6 +13,7 @@ export function FileTab({ file }: FileTabProps): JSX.Element {
   const handleFileClose = () => {
     removeFile(fileId);
     clearFilter();
+    clearAllPinned();
   };
 
   return (

--- a/apps/web/app/components/HeadersIcons.tsx
+++ b/apps/web/app/components/HeadersIcons.tsx
@@ -1,11 +1,12 @@
-import { HeaderValueFormatter } from "../providers/headerValueFormatter";
+import { Formatter } from "../providers/Formatter";
+import { HeaderItem } from "../providers/headerValueFormatter";
 
 export const HeadersIcons = ({
   formatters,
   setFormatter,
 }: {
   formatters: {
-    [id: string]: HeaderValueFormatter;
+    [id: string]: Formatter<HeaderItem>;
   };
   setFormatter: (id: string) => void;
 }): JSX.Element | null => {

--- a/apps/web/app/components/KeepPagesToggle.tsx
+++ b/apps/web/app/components/KeepPagesToggle.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import ToggleSwitch from "./ToggleSwitch";
+
+export default function KeepPagesToggle(props: {
+  isActive: boolean;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+}) {
+  const { isActive, checked, onChange } = props;
+
+  const labelClasses = `${isActive ? "" : "opacity-40"} mt-0.5 text-sm uppercase`;
+
+  return (
+    <div className="flex items-center gap-2">
+      <div className={labelClasses}>Keep pages</div>
+      <ToggleSwitch
+        checked={checked}
+        disabled={!isActive}
+        onChange={onChange}
+        size="small"
+      />
+    </div>
+  );
+}

--- a/apps/web/app/components/List.tsx
+++ b/apps/web/app/components/List.tsx
@@ -4,6 +4,7 @@ import {
   selectFilter,
   selectListData,
   selectSettings,
+  selectShowPages,
   selectSorting,
 } from "../store/selectors";
 import { setFilteredCount } from "../store/actions";
@@ -53,8 +54,9 @@ function sortItemsArray(
 export function List(): JSX.Element {
   const filter = useAppStore(selectFilter);
   const rawListData = useAppStore(selectListData);
-  const { showPages, hideEmptyPages } = useAppStore(selectSettings);
+  const { hideEmptyPages } = useAppStore(selectSettings);
   const sorting = useAppStore(selectSorting);
+  const showPages = useAppStore(selectShowPages);
 
   const entriesWithVisibility = rawListData.map(markVisible(filter));
   const visibleEntries = entriesWithVisibility.filter(

--- a/apps/web/app/components/List.tsx
+++ b/apps/web/app/components/List.tsx
@@ -3,8 +3,10 @@ import { useAppStore } from "../store/store";
 import {
   selectFilter,
   selectListData,
+  selectPinnedIds,
   selectSettings,
   selectShowPages,
+  selectShowPinnedOnly,
   selectSorting,
 } from "../store/selectors";
 import { setFilteredCount } from "../store/actions";
@@ -57,8 +59,15 @@ export function List(): JSX.Element {
   const { hideEmptyPages } = useAppStore(selectSettings);
   const sorting = useAppStore(selectSorting);
   const showPages = useAppStore(selectShowPages);
+  const showPinnedOnly = useAppStore(selectShowPinnedOnly);
+  const pinnedIds = useAppStore(selectPinnedIds);
 
-  const entriesWithVisibility = rawListData.map(markVisible(filter));
+  const rawListPinned =
+    showPinnedOnly && pinnedIds.size > 0
+      ? rawListData.filter((entry: any) => pinnedIds.has(entry.$$id))
+      : rawListData;
+
+  const entriesWithVisibility = rawListPinned.map(markVisible(filter));
   const visibleEntries = entriesWithVisibility.filter(
     (entry: any) => !entry.$$hidden,
   );

--- a/apps/web/app/components/ListItem.tsx
+++ b/apps/web/app/components/ListItem.tsx
@@ -6,6 +6,7 @@ import { Url } from "./Url";
 import { Status } from "./Status";
 import { DateTime } from "./DateTime";
 import { Time } from "./Time";
+import ListItemWrapper from "./ListItemWrapper";
 
 export function ListItem({ item }: { item: any }): JSX.Element {
   const rowId = useAppStore(selectRowId);
@@ -20,46 +21,50 @@ export function ListItem({ item }: { item: any }): JSX.Element {
     time,
     $$id,
     $$hidden,
+    $$pinned,
   } = item;
 
   const isError = parseInt(status) <= 599 && parseInt(status) >= 400;
 
-  const selectedClasses =
-    $$id === rowId
-      ? isError
-        ? "border-red-400 hover:border-red-600 dark:border-red-800 dark:hover:border-red-600"
-        : "border-accent-500 hover:border-accent-600 dark:border-accent-700 dark:hover:border-accent-400"
-      : isError
-        ? "border-transparent hover:border-red-200 dark:hover:border-red-950"
-        : "border-transparent hover:border-mirage-100 dark:hover:border-bunker-200";
+  const highlightNum = false;
+  const numClasses = highlightNum
+    ? "text-mirage-200 dark:bg-accent-600 rounded px-1 dark:text-black"
+    : "";
 
-  const bgClasses = isError
-    ? "bg-[#ff000013] dark:bg-[#ff00001c]"
-    : "dark:bg-bunker-800 bg-slate-100";
+  const Separator = () => <div className="text-mirage-600">|</div>;
 
   return (
-    <div
-      className={`${selectedClasses} ${bgClasses} ${$$hidden ? "opacity-20" : ""} text-mirage-800 dark:text-mirage-200 group flex w-full flex-col gap-2 rounded-xl border-2 p-2 transition-colors duration-200 hover:border-2`}
+    <ListItemWrapper
+      selected={$$id === rowId}
+      pinned={$$pinned}
+      error={isError}
+      hidden={!!$$hidden}
       onClick={() => setRowId($$id)}
     >
       <div className="flex items-center justify-between gap-1">
         <Status status={status} text={statusText} colored={true} />
+
         <div className="flex items-center gap-1 text-sm">
           <div>{(pageref ?? "").toUpperCase()}</div>
-          <div className="text-mirage-600">|</div>
+          <Separator />
           <Time time={time} />
-          <div className="text-mirage-600">|</div>
+          <Separator />
           <DateTime dateTime={startedDateTime} timeOnly={true} />
-          <div className="text-mirage-600">|</div>
-          <div className="text-mirage-200 dark:bg-accent-600 rounded px-1 dark:text-black">
-            #{$$id + 1}
-          </div>
+          <Separator />
+          <div className={`${numClasses}`}>#{$$id + 1}</div>
+          <Separator />
+          {$$pinned ? (
+            <div className="iconify material-symbols--bookmark-check-rounded text-lg text-yellow-400"></div>
+          ) : (
+            <div className="iconify material-symbols--bookmark-outline-rounded text-mirage-200 hover:text-accent-200 text-lg"></div>
+          )}
         </div>
       </div>
+
       <div className="flex gap-2">
         <Method method={method} colored={true} />
         <Url url={url} />
       </div>
-    </div>
+    </ListItemWrapper>
   );
 }

--- a/apps/web/app/components/ListItem.tsx
+++ b/apps/web/app/components/ListItem.tsx
@@ -1,6 +1,6 @@
 import { useAppStore } from "../store/store";
-import { selectRowId } from "../store/selectors";
-import { setRowId } from "../store/actions";
+import { selectPinnedIds, selectRowId } from "../store/selectors";
+import { setRowId, togglePinnedRow } from "../store/actions";
 import { Method } from "./Method";
 import { Url } from "./Url";
 import { Status } from "./Status";
@@ -10,6 +10,7 @@ import ListItemWrapper from "./ListItemWrapper";
 
 export function ListItem({ item }: { item: any }): JSX.Element {
   const rowId = useAppStore(selectRowId);
+  const pinnedIds = useAppStore(selectPinnedIds);
 
   const {
     pageref,
@@ -21,22 +22,27 @@ export function ListItem({ item }: { item: any }): JSX.Element {
     time,
     $$id,
     $$hidden,
-    $$pinned,
   } = item;
 
   const isError = parseInt(status) <= 599 && parseInt(status) >= 400;
+  const isPinned = pinnedIds.has($$id);
+  const isSelected = $$id === rowId;
 
   const highlightNum = false;
   const numClasses = highlightNum
     ? "text-mirage-200 dark:bg-accent-600 rounded px-1 dark:text-black"
     : "";
 
+  const pinnedClasses = isPinned
+    ? "iconify material-symbols--bookmark-check-rounded text-lg text-yellow-400"
+    : "iconify material-symbols--bookmark-outline-rounded text-mirage-200 hover:text-accent-200 text-lg";
+
   const Separator = () => <div className="text-mirage-600">|</div>;
 
   return (
     <ListItemWrapper
-      selected={$$id === rowId}
-      pinned={$$pinned}
+      selected={isSelected}
+      pinned={isPinned}
       error={isError}
       hidden={!!$$hidden}
       onClick={() => setRowId($$id)}
@@ -53,11 +59,10 @@ export function ListItem({ item }: { item: any }): JSX.Element {
           <Separator />
           <div className={`${numClasses}`}>#{$$id + 1}</div>
           <Separator />
-          {$$pinned ? (
-            <div className="iconify material-symbols--bookmark-check-rounded text-lg text-yellow-400"></div>
-          ) : (
-            <div className="iconify material-symbols--bookmark-outline-rounded text-mirage-200 hover:text-accent-200 text-lg"></div>
-          )}
+          <div
+            className={`${pinnedClasses}`}
+            onClick={() => togglePinnedRow($$id)}
+          ></div>
         </div>
       </div>
 

--- a/apps/web/app/components/ListItem.tsx
+++ b/apps/web/app/components/ListItem.tsx
@@ -34,8 +34,8 @@ export function ListItem({ item }: { item: any }): JSX.Element {
     : "";
 
   const pinnedClasses = isPinned
-    ? "iconify material-symbols--bookmark-check-rounded text-lg text-yellow-400"
-    : "iconify material-symbols--bookmark-outline-rounded text-mirage-200 hover:text-accent-200 text-lg";
+    ? "iconify material-symbols--bookmark-check-rounded text-lg text-yellow-600"
+    : "iconify material-symbols--bookmark-outline-rounded hover:text-accent-700 dark:text-mirage-200 dark:hover:text-accent-200 text-lg";
 
   const Separator = () => <div className="text-mirage-600">|</div>;
 

--- a/apps/web/app/components/ListItemWrapper.tsx
+++ b/apps/web/app/components/ListItemWrapper.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+
+export default function ListItemWrapper({
+  selected = false,
+  pinned = false,
+  error = false,
+  hidden = false,
+  onClick,
+  children,
+}: {
+  selected?: boolean;
+  pinned?: boolean;
+  error?: boolean;
+  hidden?: boolean;
+  onClick?: () => void;
+  children: React.ReactNode;
+}) {
+  const selectedClasses = selected
+    ? error
+      ? "border-red-400 hover:border-red-600 dark:border-red-800 dark:hover:border-red-600"
+      : "border-accent-500 hover:border-accent-600 dark:border-accent-700 dark:hover:border-accent-400"
+    : error
+      ? "border-transparent hover:border-red-200 dark:hover:border-red-950"
+      : "border-transparent hover:border-mirage-100 dark:hover:border-bunker-200";
+
+  const baseBg = error
+    ? "bg-[#ff000013] dark:bg-[#ff00001c]"
+    : "dark:bg-bunker-800 bg-slate-100";
+  const bgClasses = `${baseBg}${pinned ? " pinned-overlay" : ""}`;
+
+  const containerClass = `${selectedClasses} ${bgClasses} ${hidden ? "opacity-20" : ""} text-mirage-800 dark:text-mirage-200 group flex w-full flex-col gap-2 rounded-xl border-2 p-2 transition-colors duration-200 hover:border-2 relative`;
+
+  return (
+    <div className={containerClass} onClick={onClick}>
+      {children}
+    </div>
+  );
+}

--- a/apps/web/app/components/ListSorting.tsx
+++ b/apps/web/app/components/ListSorting.tsx
@@ -2,56 +2,31 @@ import React from "react";
 import { useAppStore } from "../store/store";
 import { selectSorting } from "../store/selectors";
 import { setSorting, clearSorting, setSortInsidePages } from "../store/actions";
-import Button from "./Button";
-import ToggleSwitch from "./ToggleSwitch";
+import ListSortingBtn from "./ListSortingBtn";
+import KeepPagesToggle from "./KeepPagesToggle";
+import ResetSortingBtn from "./ResetSortingBtn";
 
-const FIELDS: {
-  key: "url" | "status" | "method" | "time" | "pageref";
-  label: string;
-  icon?: string;
-}[] = [
-  {
-    key: "url",
-    label: "URL",
-    icon: "material-symbols--arrow-cool-down-rounded",
-  },
-  {
-    key: "status",
-    label: "Status",
-    icon: "material-symbols--arrow-cool-down-rounded",
-  },
-  {
-    key: "method",
-    label: "Method",
-    icon: "material-symbols--arrow-warm-up-rounded",
-  },
-  {
-    key: "time",
-    label: "Time",
-    icon: "material-symbols--arrow-cool-down-rounded",
-  },
-  {
-    key: "pageref",
-    label: "Page",
-    icon: "material-symbols--arrow-cool-down-rounded",
-  },
+type SortKey = "url" | "status" | "method" | "time" | "pageref";
+
+const SORT_FIELDS: { key: SortKey; label: string }[] = [
+  { key: "url", label: "URL" },
+  { key: "status", label: "Status" },
+  { key: "method", label: "Method" },
+  { key: "time", label: "Time" },
+  { key: "pageref", label: "Page" },
 ];
 
 export function ListSorting() {
   const { sortDir, sortBy, sortInsidePages } = useAppStore(selectSorting);
   const isActive = Boolean(sortBy);
 
-  const onFieldClick = (key: (typeof FIELDS)[number]["key"]) => setSorting(key);
+  const onFieldClick = (sortKey: SortKey) => setSorting(sortKey);
   const onToggleInsidePages = (checked: boolean) => setSortInsidePages(checked);
   const onResetSorting = () => clearSorting();
 
   const panelClasses = isActive
     ? "bg-accent-700 text-white dark:bg-accent-800 dark:text-white"
     : "bg-mirage-50 text-black dark:bg-bunker-500 dark:text-mirage-200";
-
-  const buttonHoverClasses = isActive
-    ? "dark:hover:bg-accent-700 hover:bg-accent-800 dark:hover:text-white"
-    : "opacity-25";
 
   const iconClasses = isActive
     ? "dark:text-accent-100 text-accent-100"
@@ -68,52 +43,25 @@ export function ListSorting() {
       <div className="ml-1 uppercase">Sort by</div>
 
       <div className="flex flex-1 items-center justify-center gap-4">
-        {FIELDS.map(({ key, label }) => {
-          const fieldIsActive = sortBy === key;
-          const variant = fieldIsActive ? "primary" : "flat";
-
-          const icon = fieldIsActive
-            ? sortDir === "asc"
-              ? "iconify material-symbols--arrow-upward-rounded"
-              : "iconify material-symbols--arrow-downward-rounded"
-            : "";
-
-          return (
-            <Button
-              key={key}
-              variant={variant as any}
-              icon={icon}
-              size="nr"
-              onClick={() => onFieldClick(key)}
-              className="flex items-center gap-2 py-0"
-            >
-              {label}
-            </Button>
-          );
-        })}
+        {SORT_FIELDS.map(({ key, label }) => (
+          <ListSortingBtn
+            key={key}
+            sortKey={key}
+            label={label}
+            isSelected={sortBy === key}
+            sortDir={sortDir}
+            onClick={onFieldClick}
+          />
+        ))}
       </div>
 
-      <div className="flex items-center gap-2">
-        <div
-          className={`${isActive ? "" : "opacity-40"} mt-0.5 text-sm uppercase`}
-        >
-          Keep pages
-        </div>
-        <ToggleSwitch
-          checked={!!sortInsidePages}
-          disabled={!isActive}
-          onChange={onToggleInsidePages}
-          size="small"
-        />
-      </div>
+      <KeepPagesToggle
+        isActive={isActive}
+        checked={Boolean(sortInsidePages)}
+        onChange={onToggleInsidePages}
+      />
 
-      <button
-        className={`${buttonHoverClasses} flex rounded-md p-1 text-xl`}
-        onClick={onResetSorting}
-        disabled={!isActive}
-      >
-        <span className="iconify material-symbols--delete-outline-rounded my-auto" />
-      </button>
+      <ResetSortingBtn isActive={isActive} onClick={onResetSorting} />
     </div>
   );
 }

--- a/apps/web/app/components/ListSortingBtn.tsx
+++ b/apps/web/app/components/ListSortingBtn.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import Button from "./Button";
+
+type SortKey = "url" | "status" | "method" | "time" | "pageref";
+type SortDir = "asc" | "desc";
+
+function getSortDirIcon(sortDir: SortDir) {
+  return sortDir === "asc"
+    ? "iconify material-symbols--arrow-upward-rounded"
+    : "iconify material-symbols--arrow-downward-rounded";
+}
+
+export default function ListSortingBtn(props: {
+  sortKey: SortKey;
+  label: string;
+  isSelected: boolean;
+  sortDir: SortDir;
+  onClick: (sortKey: SortKey) => void;
+}) {
+  const { sortKey, label, isSelected, sortDir, onClick } = props;
+
+  const variant = isSelected ? "primary" : "flat";
+  const icon = isSelected ? getSortDirIcon(sortDir) : "";
+
+  return (
+    <Button
+      variant={variant}
+      icon={icon}
+      size="nr"
+      onClick={() => onClick(sortKey)}
+      className="flex items-center gap-2 py-0"
+    >
+      {label}
+    </Button>
+  );
+}

--- a/apps/web/app/components/Modal.tsx
+++ b/apps/web/app/components/Modal.tsx
@@ -1,6 +1,8 @@
 "use client";
 import React, { useEffect, useRef } from "react";
 
+type Size = "small" | "medium" | "big" | "full";
+
 type ModalProps = {
   isOpen: boolean;
   onClose: () => void;
@@ -8,6 +10,8 @@ type ModalProps = {
   children?: React.ReactNode;
   closeOnBackdropClick?: boolean;
   className?: string;
+  size?: Size;
+  footer?: React.ReactNode;
 };
 
 export default function Modal({
@@ -17,6 +21,8 @@ export default function Modal({
   children,
   closeOnBackdropClick = true,
   className = "",
+  size = "medium",
+  footer,
 }: ModalProps) {
   const dialogRef = useRef<HTMLDialogElement | null>(null);
 
@@ -87,6 +93,33 @@ export default function Modal({
     };
   }, [onClose, closeOnBackdropClick]);
 
+  // compute panel class based on size
+  const panelBase =
+    "select-none overflow-hidden rounded-lg bg-white shadow-xl dark:bg-slate-800 flex flex-col";
+  const sizeClasses: Record<Size, string> = {
+    small: "w-[85vw] max-w-md",
+    medium: "w-[90vw] max-w-3xl",
+    big: "w-[95vw] max-w-6xl",
+    full: "w-screen h-screen max-w-none rounded-none",
+  };
+
+  const panelSizeClass = sizeClasses[size] || sizeClasses.medium;
+  const panelClass = `${panelSizeClass} ${panelBase} ${
+    size === "full" ? "overflow-auto" : ""
+  }`.trim();
+
+  // content area should scroll when it exceeds available viewport height
+  const hasFooter = Boolean(footer);
+  const contentClass =
+    size === "full"
+      ? "flex-1 overflow-auto p-4"
+      : `overflow-auto p-4 ${hasFooter ? "pb-4" : ""}`.trim();
+  const contentStyle: React.CSSProperties | undefined =
+    size === "full" ? undefined : { maxHeight: "calc(100vh - 160px)" }; // leave space for header and footer
+
+  const footerClass =
+    `flex-none border-t border-gray-200 p-4 dark:border-slate-700 bg-white dark:bg-slate-800 ${hasFooter ? "sticky bottom-0 z-10" : ""}`.trim();
+
   return (
     <dialog
       ref={dialogRef}
@@ -96,7 +129,7 @@ export default function Modal({
         className
       }
     >
-      <div className="w-[90vw] max-w-2xl select-none overflow-hidden rounded-lg bg-white shadow-xl dark:bg-slate-800">
+      <div className={panelClass}>
         <header className="flex justify-between border-b border-gray-100 bg-slate-700 dark:border-slate-700">
           <div className="px-4 py-3 font-medium uppercase text-white dark:text-gray-100">
             {title}
@@ -114,7 +147,10 @@ export default function Modal({
             ></span>
           </button>
         </header>
-        <div>{children}</div>
+        <div className={contentClass} style={contentStyle}>
+          {children}
+        </div>
+        {footer ? <div className={footerClass}>{footer}</div> : null}
       </div>
     </dialog>
   );

--- a/apps/web/app/components/Modal.tsx
+++ b/apps/web/app/components/Modal.tsx
@@ -139,7 +139,7 @@ export default function Modal({
             type="button"
             aria-label="Close"
             onClick={onClose}
-            className="flex items-center px-3 text-2xl text-gray-600 transition-colors duration-200 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-slate-600 dark:hover:text-white"
+            className="flex items-center px-3 text-2xl text-white transition-colors duration-200 hover:bg-slate-600 hover:text-white dark:text-gray-300 dark:hover:bg-slate-600 dark:hover:text-white"
           >
             <span
               aria-hidden="true"

--- a/apps/web/app/components/Panel.tsx
+++ b/apps/web/app/components/Panel.tsx
@@ -7,7 +7,7 @@ export function Panel({
   children: React.ReactNode;
 }): JSX.Element {
   return (
-    <div className="dark:bg-bunker-950 border-thin dark:border-bunker-700 flex h-1/2 w-full flex-none flex-col gap-2 overflow-auto border-r p-2 last:border-r-0 lg:h-full lg:w-1/2">
+    <div className="dark:bg-bunker-950 border-thin dark:border-bunker-100 flex h-full w-full flex-col gap-2 overflow-auto border-r border-slate-200 p-2 last:border-r-0">
       {children}
     </div>
   );

--- a/apps/web/app/components/ResetSortingBtn.tsx
+++ b/apps/web/app/components/ResetSortingBtn.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+
+export default function ResetSortingBtn(props: {
+  isActive: boolean;
+  onClick: () => void;
+}) {
+  const { isActive, onClick } = props;
+
+  const buttonHoverClasses = isActive
+    ? "dark:hover:bg-accent-700 hover:bg-accent-800 dark:hover:text-white"
+    : "opacity-25";
+
+  return (
+    <button
+      className={`${buttonHoverClasses} flex rounded-md p-1 text-xl`}
+      onClick={onClick}
+      disabled={!isActive}
+    >
+      <span className="iconify material-symbols--delete-outline-rounded my-auto" />
+    </button>
+  );
+}

--- a/apps/web/app/components/Settings.tsx
+++ b/apps/web/app/components/Settings.tsx
@@ -7,7 +7,7 @@ export function Settings() {
   return (
     <>
       <div
-        className={`iconify material-symbols--settings my-auto mr-1 text-xl dark:bg-slate-400 dark:hover:bg-slate-300`}
+        className={`iconify iconify material-symbols--settings-outline-rounded my-auto mr-1 text-xl dark:bg-slate-400 dark:hover:bg-slate-300`}
         onClick={() => setOpen(true)}
       ></div>
 

--- a/apps/web/app/components/Settings.tsx
+++ b/apps/web/app/components/Settings.tsx
@@ -7,7 +7,7 @@ export function Settings() {
   return (
     <>
       <div
-        className={`iconify iconify material-symbols--settings-outline-rounded my-auto mr-1 text-xl dark:bg-slate-400 dark:hover:bg-slate-300`}
+        className={`iconify material-symbols--settings-outline-rounded my-auto mr-1 text-xl dark:bg-slate-400 dark:hover:bg-slate-300`}
         onClick={() => setOpen(true)}
       ></div>
 

--- a/apps/web/app/components/Settings.tsx
+++ b/apps/web/app/components/Settings.tsx
@@ -1,15 +1,16 @@
 import React, { useState } from "react";
 import SettingsModal from "./SettingsModal";
+import { ActionIcon } from "./ActionIcon";
 
 export function Settings() {
   const [open, setOpen] = useState(false);
 
   return (
     <>
-      <div
-        className={`iconify material-symbols--settings-outline-rounded my-auto mr-1 text-xl dark:bg-slate-400 dark:hover:bg-slate-300`}
+      <ActionIcon
         onClick={() => setOpen(true)}
-      ></div>
+        icon="iconify material-symbols--settings-outline-rounded"
+      />
 
       <SettingsModal open={open} onClose={() => setOpen(false)} />
     </>

--- a/apps/web/app/components/SettingsList.tsx
+++ b/apps/web/app/components/SettingsList.tsx
@@ -91,12 +91,12 @@ export default function SettingsList({ items, form, onChange }: Props) {
         className="flex justify-between border-b border-gray-200 py-2 last:border-b-0 dark:border-slate-700"
       >
         <div className="mr-4">
-          <div className="text-mirage-800 text-md font-medium dark:text-white">
+          <div className="text-md font-medium text-black dark:text-white">
             {it.label}
           </div>
 
           {it.desc && (
-            <div className="text-mirage-500 dark:text-mirage-300 text-sm">
+            <div className="dark:text-mirage-300 text-sm text-slate-500">
               {it.desc}
             </div>
           )}

--- a/apps/web/app/components/SettingsModal.tsx
+++ b/apps/web/app/components/SettingsModal.tsx
@@ -22,12 +22,6 @@ export type SettingItem = {
 
 const items: SettingItem[] = [
   {
-    key: "showPages",
-    label: "Show Pages",
-    desc: "Group requests by pages if pages are defined.",
-    type: "switch",
-  },
-  {
     key: "hideEmptyPages",
     label: "Exclude Empty Pages",
     desc: "Hide pages that contain no entries.",

--- a/apps/web/app/components/SettingsModal.tsx
+++ b/apps/web/app/components/SettingsModal.tsx
@@ -61,29 +61,33 @@ export default function SettingsModal({ open, onClose }: Props) {
     onClose();
   };
 
+  const footer = (
+    <div className="flex w-full items-center gap-2">
+      <Button variant="ghost" onClick={resetToDefaults} className="mr-auto">
+        Reset to default
+      </Button>
+      <Button onClick={onClose}>Cancel</Button>
+      <Button variant="primary" onClick={save}>
+        Save
+      </Button>
+    </div>
+  );
+
   return (
     <Modal
       isOpen={open}
       onClose={onClose}
       title="Settings"
+      size="small"
       closeOnBackdropClick
+      footer={footer}
     >
-      <div className="space-y-2 p-4">
+      <div className="space-y-2">
         <SettingsList
           items={items}
           form={form}
           onChange={(k, v) => setFormValue(k, v)}
         />
-      </div>
-
-      <div className="flex justify-end gap-2 border-t border-gray-200 p-4 dark:border-slate-700">
-        <Button variant="ghost" onClick={resetToDefaults} className="mr-auto">
-          Reset to default
-        </Button>
-        <Button onClick={onClose}>Cancel</Button>
-        <Button variant="primary" onClick={save}>
-          Save
-        </Button>
       </div>
     </Modal>
   );

--- a/apps/web/app/components/SplitPanels.tsx
+++ b/apps/web/app/components/SplitPanels.tsx
@@ -1,0 +1,91 @@
+"use client";
+import React, { useRef, useState } from "react";
+
+type Props = {
+  left: React.ReactNode;
+  right: React.ReactNode;
+  initialLeftPercent?: number;
+  minLeftPercent?: number;
+  maxLeftPercent?: number;
+};
+
+export default function SplitPanels({
+  left,
+  right,
+  initialLeftPercent = 50,
+  minLeftPercent = 25,
+  maxLeftPercent = 75,
+}: Props) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  const [leftPercent, setLeftPercent] = useState<number>(initialLeftPercent);
+  const [isDragging, setIsDragging] = useState(false);
+  const [isHoveringDivider, setIsHoveringDivider] = useState(false);
+
+  const resetToCenter = () => {
+    setLeftPercent(50);
+  };
+
+  const startDrag = (event: React.PointerEvent<HTMLDivElement>) => {
+    const containerNode = containerRef.current;
+    if (!containerNode) return;
+
+    event.currentTarget.setPointerCapture(event.pointerId);
+    setIsDragging(true);
+
+    const onMove = (moveEvent: PointerEvent) => {
+      const rect = containerNode.getBoundingClientRect();
+      const x = moveEvent.clientX - rect.left;
+      let nextPercent = (x / rect.width) * 100;
+      if (nextPercent < minLeftPercent) nextPercent = minLeftPercent;
+      if (nextPercent > maxLeftPercent) nextPercent = maxLeftPercent;
+      setLeftPercent(nextPercent);
+    };
+
+    const onUp = () => {
+      setIsDragging(false);
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+    };
+
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onUp);
+  };
+
+  const dividerBase =
+    "w-[5px] cursor-ew-resize bg-bunker-600 transition-colors duration-150 border-l-[2px] border-r-[2px] border-bunker-950";
+  const dividerHover =
+    "bg-slate-200 dark:bg-bunker-500 border-slate-200 dark:border-bunker-500";
+  const dividerActive =
+    "bg-slate-300 dark:bg-bunker-500 border-slate-300 dark:border-bunker-500";
+
+  const dividerClassName = `${dividerBase} ${
+    isDragging ? dividerActive : isHoveringDivider ? dividerHover : ""
+  }`;
+
+  return (
+    <div ref={containerRef} className="flex h-full w-full items-stretch">
+      <div
+        style={{ flexBasis: `${leftPercent}%`, flexGrow: 0, flexShrink: 0 }}
+        className="h-full min-w-0"
+      >
+        {left}
+      </div>
+
+      <div
+        role="separator"
+        aria-orientation="vertical"
+        onPointerDown={startDrag}
+        onDoubleClick={resetToCenter}
+        onPointerEnter={() => setIsHoveringDivider(true)}
+        onPointerLeave={() => setIsHoveringDivider(false)}
+        className={dividerClassName}
+        style={{ touchAction: "none" }}
+      />
+
+      <div style={{ flex: 1, minWidth: 0 }} className="h-full min-w-0">
+        {right}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/components/SplitPanels.tsx
+++ b/apps/web/app/components/SplitPanels.tsx
@@ -53,7 +53,7 @@ export default function SplitPanels({
   };
 
   const dividerBase =
-    "w-[5px] cursor-ew-resize bg-bunker-600 transition-colors duration-150 border-l-[2px] border-r-[2px] border-bunker-950";
+    "w-[5px] cursor-ew-resize bg-bunker-600 transition-colors duration-300 border-l-[2px] border-r-[2px] border-bunker-950";
   const dividerHover =
     "bg-slate-200 dark:bg-bunker-500 border-slate-200 dark:border-bunker-500";
   const dividerActive =

--- a/apps/web/app/components/SplitPanels.tsx
+++ b/apps/web/app/components/SplitPanels.tsx
@@ -53,11 +53,11 @@ export default function SplitPanels({
   };
 
   const dividerBase =
-    "w-[5px] cursor-ew-resize bg-bunker-600 transition-colors duration-300 border-l-[2px] border-r-[2px] border-bunker-950";
+    "w-[5px] cursor-ew-resize bg-slate-200 dark:bg-bunker-600 transition-colors duration-300 border-l-[2px] border-r-[2px] dark:border-bunker-950 border-white";
   const dividerHover =
-    "bg-slate-200 dark:bg-bunker-500 border-slate-200 dark:border-bunker-500";
+    "bg-slate-400 dark:bg-bunker-500 border-slate-400 dark:border-bunker-500";
   const dividerActive =
-    "bg-slate-300 dark:bg-bunker-500 border-slate-300 dark:border-bunker-500";
+    "bg-slate-500 dark:bg-bunker-500 border-slate-500 dark:border-bunker-500";
 
   const dividerClassName = `${dividerBase} ${
     isDragging ? dividerActive : isHoveringDivider ? dividerHover : ""

--- a/apps/web/app/components/UrlDetailsModal.tsx
+++ b/apps/web/app/components/UrlDetailsModal.tsx
@@ -61,7 +61,7 @@ export default function UrlDetailsModal({ url }: { url: string }) {
           value: (
             <>
               <div className="break-all">
-                {parsed.search || <span className="text-mirage-400">—</span>}
+                {parsed.search || <span className="text-mirage-600">—</span>}
               </div>
               {queryEntries.length > 0 && (
                 <div className="mt-2">

--- a/apps/web/app/components/UrlDetailsModal.tsx
+++ b/apps/web/app/components/UrlDetailsModal.tsx
@@ -1,0 +1,124 @@
+import React, { useMemo, useState } from "react";
+import Modal from "./Modal";
+import UrlQueryTable from "./UrlQueryTable";
+import Button from "./Button";
+
+export default function UrlDetailsModal({ url }: { url: string }) {
+  const [open, setOpen] = useState(false);
+
+  const parsed = useMemo(() => {
+    try {
+      return new URL(url);
+    } catch {
+      return null;
+    }
+  }, [url]);
+
+  const queryEntries = useMemo(() => {
+    if (!parsed) return [] as Array<[string, string]>;
+    return Array.from(parsed.searchParams.entries());
+  }, [parsed]);
+
+  // map human label to URL property name used by MDN
+  const labelToPropertyMap: Record<string, string> = {
+    Href: "href",
+    Origin: "origin",
+    Protocol: "protocol",
+    Host: "host",
+    Hostname: "hostname",
+    Port: "port",
+    Pathname: "pathname",
+    Search: "search",
+    Hash: "hash",
+    Username: "username",
+    Password: "password",
+  };
+
+  const openMdnFor = (label: string) => {
+    const prop = labelToPropertyMap[label] || label.toLowerCase();
+    const mdnUrl = `https://developer.mozilla.org/en-US/docs/Web/API/URL/${encodeURIComponent(
+      prop,
+    )}`;
+    window.open(mdnUrl, "_blank");
+  };
+
+  const parts: Array<{ label: string; value: React.ReactNode }> =
+    useMemo(() => {
+      if (!parsed) return [{ label: "Invalid URL", value: url }];
+      return [
+        { label: "Href", value: parsed.href },
+        { label: "Origin", value: parsed.origin },
+        { label: "Protocol", value: parsed.protocol },
+        { label: "Host", value: parsed.host },
+        { label: "Hostname", value: parsed.hostname },
+        { label: "Port", value: parsed.port || "" },
+        { label: "Pathname", value: parsed.pathname },
+        { label: "Hash", value: parsed.hash || "" },
+        { label: "Username", value: parsed.username || "" },
+        { label: "Password", value: parsed.password || "" },
+        {
+          label: "Search",
+          value: (
+            <>
+              <div className="break-all">
+                {parsed.search || <span className="text-mirage-400">—</span>}
+              </div>
+              {queryEntries.length > 0 && (
+                <div className="mt-2">
+                  <UrlQueryTable entries={queryEntries} />
+                </div>
+              )}
+            </>
+          ),
+        },
+      ];
+    }, [parsed, url, queryEntries]);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        title="Show URL details"
+        className="iconify material-symbols--list-alt-outline-rounded text-accent-400 hover:text-accent-200 text-xl"
+      />
+
+      <Modal
+        isOpen={open}
+        onClose={() => setOpen(false)}
+        title="URL details"
+        size="medium"
+        closeOnBackdropClick
+        footer={
+          <div className="flex justify-end gap-2">
+            <Button variant="primary" onClick={() => setOpen(false)}>
+              OK
+            </Button>
+          </div>
+        }
+      >
+        <div className="select-text">
+          <div className="rounded-md bg-transparent">
+            {parts.map(({ label, value }) => (
+              <div
+                key={label}
+                className="grid grid-cols-9 gap-4 border-b border-gray-200 py-2 last:border-b-0 dark:border-slate-700"
+              >
+                <div className="text-mirage-700 col-span-2 flex text-sm font-medium dark:text-white">
+                  <span className="">{label}</span>
+                  <span
+                    className="iconify material-symbols--help-outline-rounded dark:text-mirage-600 text-mirage-100 dark:hover:text-accent-300 hover:text-accent-600 ml-1 inline-flex cursor-pointer select-none items-center align-top text-lg"
+                    onClick={() => openMdnFor(label)}
+                  />
+                </div>
+                <div className="text-mirage-700 dark:text-mirage-200 col-span-7 break-all text-sm">
+                  {value || <span className="text-mirage-600">—</span>}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </Modal>
+    </>
+  );
+}

--- a/apps/web/app/components/UrlDetailsModal.tsx
+++ b/apps/web/app/components/UrlDetailsModal.tsx
@@ -61,7 +61,11 @@ export default function UrlDetailsModal({ url }: { url: string }) {
           value: (
             <>
               <div className="break-all">
-                {parsed.search || <span className="text-mirage-600">—</span>}
+                {parsed.search || (
+                  <span className="dark:text-mirage-600 text-mirage-300">
+                    —
+                  </span>
+                )}
               </div>
               {queryEntries.length > 0 && (
                 <div className="mt-2">
@@ -80,7 +84,7 @@ export default function UrlDetailsModal({ url }: { url: string }) {
         type="button"
         onClick={() => setOpen(true)}
         title="Show URL details"
-        className="iconify material-symbols--list-alt-outline-rounded text-accent-400 hover:text-accent-200 text-xl"
+        className="iconify material-symbols--list-alt-outline-rounded dark:text-accent-400 dark:hover:text-accent-200 text-accent-600 hover:text-accent-700 text-xl"
       />
 
       <Modal
@@ -104,15 +108,19 @@ export default function UrlDetailsModal({ url }: { url: string }) {
                 key={label}
                 className="grid grid-cols-9 gap-4 border-b border-gray-200 py-2 last:border-b-0 dark:border-slate-700"
               >
-                <div className="text-mirage-700 col-span-2 flex text-sm font-medium dark:text-white">
+                <div className="col-span-2 flex text-sm font-medium text-black dark:text-white">
                   <span className="">{label}</span>
                   <span
                     className="iconify material-symbols--help-outline-rounded dark:text-mirage-600 text-mirage-100 dark:hover:text-accent-300 hover:text-accent-600 ml-1 inline-flex cursor-pointer select-none items-center align-top text-lg"
                     onClick={() => openMdnFor(label)}
                   />
                 </div>
-                <div className="text-mirage-700 dark:text-mirage-200 col-span-7 break-all text-sm">
-                  {value || <span className="text-mirage-600">—</span>}
+                <div className="dark:text-mirage-200 col-span-7 break-all text-sm text-black">
+                  {value || (
+                    <span className="dark:text-mirage-600 text-mirage-300">
+                      —
+                    </span>
+                  )}
                 </div>
               </div>
             ))}

--- a/apps/web/app/components/UrlQueryTable.tsx
+++ b/apps/web/app/components/UrlQueryTable.tsx
@@ -1,0 +1,33 @@
+"use client";
+import React from "react";
+
+type Props = {
+  entries: Array<[string, string]>;
+};
+
+export default function UrlQueryTable({ entries }: Props) {
+  if (!entries || entries.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="rounded-md bg-transparent">
+      {entries.map(([paramKey, paramValue], index) => {
+        const rowHasBorder = index < entries.length - 1;
+        const rowClassName = `grid grid-cols-12 py-1 ${
+          rowHasBorder ? "border-b border-gray-200 dark:border-slate-700" : ""
+        }`;
+        return (
+          <div key={`${paramKey}-${index}`} className={rowClassName}>
+            <div className="text-mirage-700 col-span-4 pr-2 text-sm font-medium dark:text-white">
+              {paramKey}
+            </div>
+            <div className="text-mirage-700 dark:text-mirage-200 col-span-8 break-all pl-2 text-sm">
+              <span className="text-mirage-600">=</span> {paramValue}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/app/components/UrlQueryTable.tsx
+++ b/apps/web/app/components/UrlQueryTable.tsx
@@ -19,10 +19,10 @@ export default function UrlQueryTable({ entries }: Props) {
         }`;
         return (
           <div key={`${paramKey}-${index}`} className={rowClassName}>
-            <div className="text-mirage-700 col-span-4 pr-2 text-sm font-medium dark:text-white">
+            <div className="text-mirage-800 col-span-4 pr-2 text-sm font-medium dark:text-white">
               {paramKey}
             </div>
-            <div className="text-mirage-700 dark:text-mirage-200 col-span-8 break-all pl-2 text-sm">
+            <div className="text-mirage-800 dark:text-mirage-200 col-span-8 break-all pl-2 text-sm">
               <span className="text-mirage-600">=</span> {paramValue}
             </div>
           </div>

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -58,6 +58,15 @@
     #a853ba 180deg,
     #e92a67 360deg
   );
+
+  /* background for pinned items: multiple layers (radial + linear) */
+  --item-gradient: radial-gradient(circle at calc(100% + 14px) 9px, rgba(245,158,11,0.25) 0, rgba(245,158,11,0.12) 5%, rgba(0,0,0,0) 16%);
+}
+
+/* helper class for pinned overlay (use together with bg-[var(--item-gradient)]) */
+.pinned-overlay {
+  background-image: var(--item-gradient);
+  /* mix-blend-mode: screen; */
 }
 
 * {

--- a/apps/web/app/plugins/detail-enhanced-formatter/index.tsx
+++ b/apps/web/app/plugins/detail-enhanced-formatter/index.tsx
@@ -1,7 +1,8 @@
-import { Formatter } from "../../providers/contentValueFormatter";
+import { Formatter } from "../../providers/Formatter";
 import { Detail } from "../../components/Detail";
 
 export const detailEnhancedFormatter: Formatter<any> = {
+  id: "detail-enhanced-formatter",
   title: "Table",
   icon: "iconify material-symbols--table-rows-outline",
   tooltip: "Detail enhanced view",

--- a/apps/web/app/plugins/detail-raw-formatter/index.tsx
+++ b/apps/web/app/plugins/detail-raw-formatter/index.tsx
@@ -1,7 +1,8 @@
-import { Formatter } from "../../providers/contentValueFormatter";
+import { Formatter } from "../../providers/Formatter";
 import { JsonContent } from "../../components/JsonContent";
 
 export const detailRawFormatter: Formatter<any> = {
+  id: "detail-raw-formatter",
   title: "Raw",
   icon: "iconify material-symbols--code-blocks-outline-rounded",
   tooltip: "Detail raw view",

--- a/apps/web/app/plugins/headers-raw-formatter/index.tsx
+++ b/apps/web/app/plugins/headers-raw-formatter/index.tsx
@@ -1,7 +1,9 @@
-import { Formatter, HeaderItem } from "../../providers/contentValueFormatter";
+import { Formatter } from "../../providers/Formatter";
+import { HeaderItem } from "../../providers/headerValueFormatter";
 import { JsonContent } from "../../components/JsonContent";
 
 export const headersRawFormatter: Formatter<HeaderItem[]> = {
+  id: "headers-raw-formatter",
   title: "Raw",
   icon: "iconify material-symbols--code-rounded",
   tooltip: "Raw formatted value",

--- a/apps/web/app/plugins/headers-table-formatter/index.tsx
+++ b/apps/web/app/plugins/headers-table-formatter/index.tsx
@@ -1,7 +1,9 @@
-import { Formatter, HeaderItem } from "../../providers/contentValueFormatter";
+import { Formatter } from "../../providers/Formatter";
+import { HeaderItem } from "../../providers/headerValueFormatter";
 import { HeadersTable } from "../../components/HeadersTable";
 
 export const headersTableFormatter: Formatter<HeaderItem[]> = {
+  id: "headers-table-formatter",
   title: "Table",
   icon: "iconify material-symbols--notes-rounded",
   tooltip: "Headers in table format",

--- a/apps/web/app/plugins/json-pretty-formatter/index.tsx
+++ b/apps/web/app/plugins/json-pretty-formatter/index.tsx
@@ -1,9 +1,11 @@
-import { Formatter, ContentValue } from "../../providers/contentValueFormatter";
+import { Formatter } from "../../providers/Formatter";
+import { ContentValue } from "../../providers/contentValueFormatter";
 import { TextContent } from "../../components/TextContent";
 import { JsonContent } from "../../components/JsonContent";
 import { parseJsonData } from "../../helpers/helpers";
 
 export const jsonPrettyFormatter: Formatter<ContentValue> = {
+  id: "json-pretty-formatter",
   title: "Pretty",
   icon: "iconify material-symbols--notes-rounded",
   tooltip: "Pretty formatted value",

--- a/apps/web/app/plugins/json-raw-formatter/index.tsx
+++ b/apps/web/app/plugins/json-raw-formatter/index.tsx
@@ -1,7 +1,9 @@
-import { Formatter, ContentValue } from "../../providers/contentValueFormatter";
+import { Formatter } from "../../providers/Formatter";
+import { ContentValue } from "../../providers/contentValueFormatter";
 import { TextContent } from "../../components/TextContent";
 
 export const jsonRawFormatter: Formatter<ContentValue> = {
+  id: "json-raw-formatter",
   title: "Original",
   icon: "iconify material-symbols--code-rounded",
   tooltip: "Original raw value",

--- a/apps/web/app/plugins/user-agent-parse-formatter/index.tsx
+++ b/apps/web/app/plugins/user-agent-parse-formatter/index.tsx
@@ -1,11 +1,10 @@
+import { Formatter } from "../../providers/Formatter";
 import UAParser from "ua-parser-js";
-import {
-  HeaderItem,
-  HeaderValueFormatter,
-} from "../../providers/headerValueFormatter";
+import { HeaderItem } from "../../providers/headerValueFormatter";
 import { InfoBadge } from "../../components/InfoBadge";
 
-export const userAgentParseFormatter: HeaderValueFormatter = {
+export const userAgentParseFormatter: Formatter<HeaderItem> = {
+  id: "user-agent-parse-formatter",
   title: "Parse",
   icon: "iconify material-symbols--notes-rounded",
   tooltip: "Parse User Agent",

--- a/apps/web/app/plugins/user-agent-raw-formatter/index.tsx
+++ b/apps/web/app/plugins/user-agent-raw-formatter/index.tsx
@@ -1,9 +1,8 @@
-import {
-  HeaderItem,
-  HeaderValueFormatter,
-} from "../../providers/headerValueFormatter";
+import { Formatter } from "../../providers/Formatter";
+import { HeaderItem } from "../../providers/headerValueFormatter";
 
-export const userAgentRawFormatter: HeaderValueFormatter = {
+export const userAgentRawFormatter: Formatter<HeaderItem> = {
+  id: "user-agent-raw-formatter",
   title: "Original",
   icon: "iconify material-symbols--code-rounded",
   tooltip: "Original raw value",

--- a/apps/web/app/providers/Formatter.ts
+++ b/apps/web/app/providers/Formatter.ts
@@ -1,0 +1,7 @@
+export type Formatter<T> = {
+  id: string;
+  title: string;
+  icon: string;
+  tooltip: string;
+  format: (data: T) => JSX.Element | string | null;
+};

--- a/apps/web/app/providers/FormatterProvider.ts
+++ b/apps/web/app/providers/FormatterProvider.ts
@@ -1,5 +1,3 @@
-import { nanoid } from "nanoid";
-
 export type FormatterProviderOptions = {
   comparativeMethod: "case-sensitive" | "case-insensitive";
 };
@@ -8,7 +6,13 @@ const defaultOptions: FormatterProviderOptions = {
   comparativeMethod: "case-insensitive",
 };
 
-export function FormatterProvider<T>(options?: FormatterProviderOptions) {
+export type FormatterBase = {
+  id: string;
+};
+
+export function FormatterProvider<T extends FormatterBase>(
+  options?: FormatterProviderOptions,
+) {
   const formatters: { [key: string]: { [id: string]: T } } = {};
   const optionsObj = { ...defaultOptions, ...options };
 
@@ -83,14 +87,14 @@ export function FormatterProvider<T>(options?: FormatterProviderOptions) {
   };
 }
 
-function prepareFormatters<T>(
+function prepareFormatters<T extends FormatterBase>(
   formatters: T[],
 ): [{ [id: string]: T }, string[]] {
   let indexes: string[] = [];
 
   const formattersCatalog = formatters.reduce(
     (acc, formatter: T) => {
-      const id: string = nanoid();
+      const id: string = formatter.id;
       indexes = [...indexes, id];
       acc[id] = formatter;
       return acc;

--- a/apps/web/app/providers/contentValueFormatter.ts
+++ b/apps/web/app/providers/contentValueFormatter.ts
@@ -1,18 +1,7 @@
+import { Formatter } from "./Formatter";
 import { FormatterProvider } from "./FormatterProvider";
 import { jsonRawFormatter } from "../plugins/json-raw-formatter";
 import { jsonPrettyFormatter } from "../plugins/json-pretty-formatter";
-
-export interface HeaderItem {
-  name: string;
-  value: string | null | undefined;
-}
-
-export type Formatter<T> = {
-  title: string;
-  icon: string;
-  tooltip: string;
-  format: (data: T) => JSX.Element | string | null;
-};
 
 export type ContentValue = {
   value: string | null | undefined;

--- a/apps/web/app/providers/detailFormatter.ts
+++ b/apps/web/app/providers/detailFormatter.ts
@@ -1,18 +1,7 @@
+import { Formatter } from "./Formatter";
 import { FormatterProvider } from "./FormatterProvider";
 import { detailEnhancedFormatter } from "../plugins/detail-enhanced-formatter";
 import { detailRawFormatter } from "../plugins/detail-raw-formatter";
-
-export interface HeaderItem {
-  name: string;
-  value: string | null | undefined;
-}
-
-export type Formatter<T> = {
-  title: string;
-  icon: string;
-  tooltip: string;
-  format: (data: T) => JSX.Element | string | null;
-};
 
 export const detailFormatters = FormatterProvider<Formatter<any>>();
 

--- a/apps/web/app/providers/headerValueFormatter.ts
+++ b/apps/web/app/providers/headerValueFormatter.ts
@@ -1,3 +1,4 @@
+import { Formatter } from "./Formatter";
 import { FormatterProvider } from "./FormatterProvider";
 import { userAgentParseFormatter } from "../plugins/user-agent-parse-formatter";
 import { userAgentRawFormatter } from "../plugins/user-agent-raw-formatter";
@@ -7,14 +8,7 @@ export interface HeaderItem {
   value: string | null | undefined;
 }
 
-export type HeaderValueFormatter = {
-  title: string;
-  icon: string;
-  tooltip: string;
-  format: (headerItem: HeaderItem) => JSX.Element | string | null;
-};
-
-export const headerValueFormatters = FormatterProvider<HeaderValueFormatter>();
+export const headerValueFormatters = FormatterProvider<Formatter<HeaderItem>>();
 
 headerValueFormatters.addFormatters("User-Agent", [userAgentParseFormatter]);
 headerValueFormatters.addFormatters("User-Agent", [userAgentRawFormatter]);

--- a/apps/web/app/providers/headersFormatter.ts
+++ b/apps/web/app/providers/headersFormatter.ts
@@ -1,3 +1,4 @@
+import { Formatter } from "./Formatter";
 import { FormatterProvider } from "./FormatterProvider";
 import { headersRawFormatter } from "../plugins/headers-raw-formatter";
 import { headersTableFormatter } from "../plugins/headers-table-formatter";
@@ -6,13 +7,6 @@ export interface HeaderItem {
   name: string;
   value: string | null | undefined;
 }
-
-export type Formatter<T> = {
-  title: string;
-  icon: string;
-  tooltip: string;
-  format: (data: T) => JSX.Element | string | null;
-};
 
 export const headersFormatters = FormatterProvider<Formatter<HeaderItem[]>>();
 

--- a/apps/web/app/store/actions.ts
+++ b/apps/web/app/store/actions.ts
@@ -142,3 +142,14 @@ export const setDetailFormatter = (formatterId: string) =>
   useAppStore.setState((state) => ({
     uiPersistent: { ...state.uiPersistent, detailFormatterId: formatterId },
   }));
+
+export const togglePinnedRow = (rowId: number) =>
+  useAppStore.setState((state) => {
+    const pinnedIds = new Set(state.ui.pinnedIds);
+    if (pinnedIds.has(rowId)) {
+      pinnedIds.delete(rowId);
+    } else {
+      pinnedIds.add(rowId);
+    }
+    return { ui: { ...state.ui, pinnedIds } };
+  });

--- a/apps/web/app/store/actions.ts
+++ b/apps/web/app/store/actions.ts
@@ -18,6 +18,11 @@ export const setRowId = (rowId: number) =>
 export const setTab = (tab: TabCode) =>
   useAppStore.setState((state) => ({ ui: { ...state.ui, tab } }));
 
+export const setShowPinnedOnly = (showPinnedOnly: boolean) =>
+  useAppStore.setState((state) => ({
+    ui: { ...state.ui, showPinnedOnly },
+  }));
+
 export const setFilterActive = (filterActive: boolean) =>
   useAppStore.setState((state) => ({
     uiPersistent: { ...state.uiPersistent, filterActive },
@@ -143,6 +148,15 @@ export const setDetailFormatter = (formatterId: string) =>
     uiPersistent: { ...state.uiPersistent, detailFormatterId: formatterId },
   }));
 
+export const clearAllPinned = () =>
+  useAppStore.setState((state) => ({
+    ui: {
+      ...state.ui,
+      pinnedIds: new Set(),
+      showPinnedOnly: false,
+    },
+  }));
+
 export const togglePinnedRow = (rowId: number) =>
   useAppStore.setState((state) => {
     const pinnedIds = new Set(state.ui.pinnedIds);
@@ -151,5 +165,11 @@ export const togglePinnedRow = (rowId: number) =>
     } else {
       pinnedIds.add(rowId);
     }
-    return { ui: { ...state.ui, pinnedIds } };
+    return {
+      ui: {
+        ...state.ui,
+        pinnedIds,
+        showPinnedOnly: pinnedIds.size > 0 ? state.ui.showPinnedOnly : false,
+      },
+    };
   });

--- a/apps/web/app/store/actions.ts
+++ b/apps/web/app/store/actions.ts
@@ -19,10 +19,19 @@ export const setTab = (tab: TabCode) =>
   useAppStore.setState((state) => ({ ui: { ...state.ui, tab } }));
 
 export const setFilterActive = (filterActive: boolean) =>
-  useAppStore.setState((state) => ({ ui: { ...state.ui, filterActive } }));
+  useAppStore.setState((state) => ({
+    uiPersistent: { ...state.uiPersistent, filterActive },
+  }));
 
 export const setSortingActive = (sortingActive: boolean) =>
-  useAppStore.setState((state) => ({ ui: { ...state.ui, sortingActive } }));
+  useAppStore.setState((state) => ({
+    uiPersistent: { ...state.uiPersistent, sortingActive },
+  }));
+
+export const setShowPages = (showPages: boolean) =>
+  useAppStore.setState((state) => ({
+    uiPersistent: { ...state.uiPersistent, showPages },
+  }));
 
 export const addFile = (file: File) =>
   useAppStore.setState((state) => ({ files: [...state.files, file] }));
@@ -129,12 +138,7 @@ export const clearSorting = () =>
     },
   }));
 
-export const setShowPages = (show: boolean) =>
-  useAppStore.setState((state) => ({
-    settings: { ...state.settings, showPages: show },
-  }));
-
 export const setDetailFormatter = (formatterId: string) =>
   useAppStore.setState((state) => ({
-    ui: { ...state.ui, detailFormatterId: formatterId },
+    uiPersistent: { ...state.uiPersistent, detailFormatterId: formatterId },
   }));

--- a/apps/web/app/store/selectors.ts
+++ b/apps/web/app/store/selectors.ts
@@ -10,6 +10,8 @@ export const selectFilter = (state: AppState) => state.filter;
 export const selectJsonViewerSettings = (state: AppState) => state.jsonViewer;
 export const selectSettings = (state: AppState) => state.settings;
 export const selectSorting = (state: AppState) => state.sorting;
+export const selectShowPinnedOnly = (state: AppState) =>
+  state.ui.showPinnedOnly;
 
 export const selectFilterActive = (state: AppState) =>
   state.uiPersistent.filterActive;

--- a/apps/web/app/store/selectors.ts
+++ b/apps/web/app/store/selectors.ts
@@ -5,6 +5,7 @@ export const selectFiles = (state: AppState) => state.files;
 export const selectFileId = (state: AppState) => state.ui.fileId;
 export const selectToasts = (state: AppState) => state.toasts;
 export const selectRowId = (state: AppState) => state.ui.rowId;
+export const selectPinnedIds = (state: AppState) => state.ui.pinnedIds;
 export const selectFilter = (state: AppState) => state.filter;
 export const selectJsonViewerSettings = (state: AppState) => state.jsonViewer;
 export const selectSettings = (state: AppState) => state.settings;

--- a/apps/web/app/store/selectors.ts
+++ b/apps/web/app/store/selectors.ts
@@ -3,16 +3,21 @@ import { AppState, TabCode } from "./store";
 export const selectTab = (state: AppState) => state.ui.tab;
 export const selectFiles = (state: AppState) => state.files;
 export const selectFileId = (state: AppState) => state.ui.fileId;
-export const selectFilterActive = (state: AppState) => state.ui.filterActive;
-export const selectSortingActive = (state: AppState) => state.ui.sortingActive;
 export const selectToasts = (state: AppState) => state.toasts;
 export const selectRowId = (state: AppState) => state.ui.rowId;
 export const selectFilter = (state: AppState) => state.filter;
 export const selectJsonViewerSettings = (state: AppState) => state.jsonViewer;
 export const selectSettings = (state: AppState) => state.settings;
 export const selectSorting = (state: AppState) => state.sorting;
+
+export const selectFilterActive = (state: AppState) =>
+  state.uiPersistent.filterActive;
+export const selectSortingActive = (state: AppState) =>
+  state.uiPersistent.sortingActive;
+export const selectShowPages = (state: AppState) =>
+  state.uiPersistent.showPages;
 export const selectDetailFormatterId = (state: AppState) =>
-  state.ui.detailFormatterId;
+  state.uiPersistent.detailFormatterId;
 
 export const selectFileSize = (state: AppState) => {
   const files = selectFiles(state);

--- a/apps/web/app/store/store.ts
+++ b/apps/web/app/store/store.ts
@@ -123,29 +123,36 @@ const settingsStorage =
     ? createJSONStorage(() => localStorage)
     : undefined;
 
+const initialState: AppState = {
+  files: [],
+  toasts: [],
+  filter: { ...initialFilterState },
+  ui: { ...initialUiState },
+  jsonViewer: { ...initialJsonViewerSettings },
+  settings: { ...initialSettings },
+  sorting: { ...initialSortingState },
+};
+
 export const useAppStore = create<AppState>()(
-  persist(
-    () => ({
-      files: [],
-      toasts: [],
-      filter: { ...initialFilterState },
-      ui: { ...initialUiState },
-      jsonViewer: { ...initialJsonViewerSettings },
-      settings: { ...initialSettings },
-      sorting: { ...initialSortingState },
+  persist<AppState>(() => initialState, {
+    name: "har-viewer-settings",
+    // storage may be undefined during SSR; cast to any to satisfy typings
+    storage: settingsStorage as any,
+    partialize: (state: AppState) => ({
+      ui: state.ui,
+      settings: state.settings,
     }),
-    {
-      name: "harviewer-settings",
-      storage: settingsStorage,
-      partialize: (state) => ({ settings: state.settings }),
-      merge: (persistedState, currentState) => ({
-        ...currentState,
-        ...persistedState,
-        settings: {
-          ...currentState.settings,
-          ...(persistedState as Partial<AppState>).settings,
-        },
-      }),
-    }
-  )
+    merge: (persistedState: Partial<AppState>, currentState: AppState) => ({
+      ...currentState,
+      ...persistedState,
+      ui: {
+        ...currentState.ui,
+        ...(persistedState as Partial<AppState>).ui,
+      },
+      settings: {
+        ...currentState.settings,
+        ...(persistedState as Partial<AppState>).settings,
+      },
+    }),
+  } as any),
 );

--- a/apps/web/app/store/store.ts
+++ b/apps/web/app/store/store.ts
@@ -39,6 +39,7 @@ export type Ui = {
   fileId: string;
   rowId: number;
   pinnedIds: Set<number>;
+  showPinnedOnly: boolean;
   tab: TabCode;
 };
 
@@ -99,6 +100,7 @@ export const initialUiState: Ui = {
   fileId: "",
   rowId: 0,
   pinnedIds: new Set<number>(),
+  showPinnedOnly: false,
   tab: "REQ",
 };
 

--- a/apps/web/app/store/store.ts
+++ b/apps/web/app/store/store.ts
@@ -38,6 +38,7 @@ export type TabCode = "REQ" | "RES" | "COO" | "TIM";
 export type Ui = {
   fileId: string;
   rowId: number;
+  pinnedIds: Set<number>;
   tab: TabCode;
 };
 
@@ -97,6 +98,7 @@ export const initialFilterState: Filter = {
 export const initialUiState: Ui = {
   fileId: "",
   rowId: 0,
+  pinnedIds: new Set<number>(),
   tab: "REQ",
 };
 

--- a/apps/web/app/store/store.ts
+++ b/apps/web/app/store/store.ts
@@ -39,8 +39,12 @@ export type Ui = {
   fileId: string;
   rowId: number;
   tab: TabCode;
+};
+
+export type UiPersistent = {
   filterActive: boolean;
   sortingActive: boolean;
+  showPages: boolean;
   detailFormatterId: string | null;
 };
 
@@ -55,24 +59,9 @@ export type JsonViewerSettings = {
 };
 
 export type Settings = {
-  showPages: boolean;
   groupHidden: boolean;
   excludeHidden: boolean;
   hideEmptyPages: boolean;
-};
-
-// default settings exported so other modules can reset to them
-export const initialSettings: Settings = {
-  showPages: false,
-  groupHidden: true,
-  excludeHidden: false,
-  hideEmptyPages: true,
-};
-
-export const initialSortingState: Sorting = {
-  sortBy: undefined,
-  sortDir: "asc",
-  sortInsidePages: false,
 };
 
 export type AppState = {
@@ -80,9 +69,16 @@ export type AppState = {
   toasts: Toast[];
   filter: Filter;
   ui: Ui;
-  jsonViewer: JsonViewerSettings;
+  uiPersistent: UiPersistent;
   settings: Settings;
   sorting: Sorting;
+  jsonViewer: JsonViewerSettings;
+};
+
+export const initialSortingState: Sorting = {
+  sortBy: undefined,
+  sortDir: "asc",
+  sortInsidePages: false,
 };
 
 export const initialFilterFieldsState: Filter["fields"] = {
@@ -102,8 +98,19 @@ export const initialUiState: Ui = {
   fileId: "",
   rowId: 0,
   tab: "REQ",
+};
+
+// default settings exported so other modules can reset to them
+export const initialSettings: Settings = {
+  groupHidden: true,
+  excludeHidden: false,
+  hideEmptyPages: true,
+};
+
+export const initialUiPersistentState: UiPersistent = {
   filterActive: true,
   sortingActive: false,
+  showPages: false,
   detailFormatterId:
     detailFormatters.getDefaultFormatter("detail")?.[0] || null,
 };
@@ -128,9 +135,10 @@ const initialState: AppState = {
   toasts: [],
   filter: { ...initialFilterState },
   ui: { ...initialUiState },
-  jsonViewer: { ...initialJsonViewerSettings },
+  uiPersistent: { ...initialUiPersistentState },
   settings: { ...initialSettings },
   sorting: { ...initialSortingState },
+  jsonViewer: { ...initialJsonViewerSettings },
 };
 
 export const useAppStore = create<AppState>()(
@@ -139,15 +147,15 @@ export const useAppStore = create<AppState>()(
     // storage may be undefined during SSR; cast to any to satisfy typings
     storage: settingsStorage as any,
     partialize: (state: AppState) => ({
-      ui: state.ui,
+      uiPersistent: state.uiPersistent,
       settings: state.settings,
     }),
     merge: (persistedState: Partial<AppState>, currentState: AppState) => ({
       ...currentState,
       ...persistedState,
-      ui: {
-        ...currentState.ui,
-        ...(persistedState as Partial<AppState>).ui,
+      uiPersistent: {
+        ...currentState.uiPersistent,
+        ...(persistedState as Partial<AppState>).uiPersistent,
       },
       settings: {
         ...currentState.settings,


### PR DESCRIPTION
### Motivation
- Persist user `settings` across browser sessions so preferences survive reloads and restarts.
- Ensure persisted settings are merged with current defaults to avoid missing or stale fields.

### Description
- Added imports for `createJSONStorage` and `persist` from `zustand/middleware` and created a browser-only `settingsStorage` guard that uses `localStorage`.
- Replaced the inline `create` store with `create<AppState>()(persist(...))` and moved the initial state into the persisted factory function in `apps/web/app/store/store.ts`.
- Limited persistence to only the `settings` slice using `partialize: (state) => ({ settings: state.settings })`.
- Implemented a `merge` function to combine persisted settings with `currentState` so defaults are preserved when loading.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69775c13215c8323b71b62dd8d898e10)