### PR TITLE
Refactor selectors to fix Zustand v5 infinite re-render loops

### DIFF
--- a/apps/web/app/components/Detail.tsx
+++ b/apps/web/app/components/Detail.tsx
@@ -1,6 +1,7 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { useAppStore } from "../store/store";
-import { selectTab, selectTabData } from "../store/selectors";
+import { selectTab, selectRawEntry } from "../store/selectors";
+import { deriveTabData } from "../helpers/helpers";
 import { DetailCommon } from "./DetailCommon";
 import { DetailButtons } from "./DetailButtons";
 import { DetailSegment } from "./DetailSegment";
@@ -11,7 +12,8 @@ import { TimTab } from "./TimTab";
 
 export function Detail(): React.JSX.Element {
   const tab = useAppStore(selectTab);
-  const tabData = useAppStore(selectTabData(tab));
+  const rawEntry = useAppStore(selectRawEntry);
+  const tabData = useMemo(() => deriveTabData(rawEntry, tab), [rawEntry, tab]);
 
   return (
     <>

--- a/apps/web/app/components/DetailCommon.tsx
+++ b/apps/web/app/components/DetailCommon.tsx
@@ -1,7 +1,8 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { NA } from "@repo/ui/na";
 import { useAppStore } from "../store/store";
-import { selectCommonData } from "../store/selectors";
+import { selectRawEntry } from "../store/selectors";
+import { deriveCommonData } from "../helpers/helpers";
 import { Url } from "./Url";
 import { Method } from "./Method";
 import { Status } from "./Status";
@@ -11,7 +12,8 @@ import { LineClamp } from "@repo/ui/line-clamp";
 import UrlDetailsModal from "./UrlDetailsModal";
 
 export function DetailCommon(): React.JSX.Element | null {
-  const data = useAppStore(selectCommonData);
+  const rawEntry = useAppStore(selectRawEntry);
+  const data = useMemo(() => deriveCommonData(rawEntry), [rawEntry]);
 
   if (!data) {
     return null;

--- a/apps/web/app/components/FileContent.tsx
+++ b/apps/web/app/components/FileContent.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useShallow } from "zustand/shallow";
 import { useAppStore } from "../store/store";
 import {
   selectDetailFormatterId,
@@ -17,7 +18,8 @@ export function FileContent(): React.JSX.Element {
   const filterActive = useAppStore(selectFilterActive);
   const sortingActive = useAppStore(selectSortingActive);
   const detailFormatterId = useAppStore(selectDetailFormatterId);
-  const entry = useAppStore(selectEntry);
+  // useShallow prevents re-renders when selectEntry returns a new object with the same field values.
+  const entry = useAppStore(useShallow(selectEntry));
 
   const formatFn = detailFormatterId
     ? detailFormatters.getFormatter("detail", detailFormatterId)?.format

--- a/apps/web/app/components/FileTabs.tsx
+++ b/apps/web/app/components/FileTabs.tsx
@@ -1,10 +1,13 @@
 import type React from "react";
+import { useShallow } from "zustand/shallow";
 import { useAppStore } from "../store/store";
-import { selectFileTabs } from "../store/selectors";
+import { selectFiles } from "../store/selectors";
 import { FileTab } from "./FileTab";
 
 export function FileTabs(): React.JSX.Element {
-  const files = useAppStore(selectFileTabs);
+  // useShallow prevents re-renders when selectFiles
+  // returns a new array with the same file references.
+  const files = useAppStore(useShallow(selectFiles));
 
   return (
     <div className="ml-8 flex h-full flex-row gap-2">

--- a/apps/web/app/components/Footer.tsx
+++ b/apps/web/app/components/Footer.tsx
@@ -1,6 +1,12 @@
+import { useMemo } from "react";
 import { NA } from "@repo/ui/na";
 import { useAppStore } from "../store/store";
-import { selectFilter, selectFooterData } from "../store/selectors";
+import {
+  selectFilter,
+  selectHarData,
+  selectFileSize,
+} from "../store/selectors";
+import { deriveFooterData } from "../helpers/helpers";
 import { formatNumber } from "../helpers/formatNumber";
 import { formatFileSize } from "../helpers/formatFileSize";
 import { formatThousands } from "../helpers/formatThousands";
@@ -18,21 +24,20 @@ export function FooterEmpty() {
 }
 
 export function Footer() {
-  const data = useAppStore(selectFooterData);
+  const harData = useAppStore(selectHarData);
+  const fileSize = useAppStore(selectFileSize);
   const { count } = useAppStore(selectFilter);
+
+  const data = useMemo(
+    () => deriveFooterData(harData, fileSize),
+    [harData, fileSize],
+  );
 
   if (!data) {
     return <FooterEmpty />;
   }
 
-  const {
-    version,
-    fileSize,
-    creatorName,
-    creatorVersion,
-    entriesNum,
-    totalTime,
-  } = data;
+  const { version, creatorName, creatorVersion, entriesNum, totalTime } = data;
 
   const filteredNum =
     count >= 0 && count !== entriesNum ? ` (filtered: ${count})` : "";

--- a/apps/web/app/components/List.tsx
+++ b/apps/web/app/components/List.tsx
@@ -1,17 +1,18 @@
 "use client";
 import type React from "react";
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import { useAppStore } from "../store/store";
 import {
   selectFilter,
-  selectListData,
   selectPinnedIds,
+  selectRawEntries,
   selectSettings,
   selectShowPages,
   selectShowPinnedOnly,
   selectSorting,
 } from "../store/selectors";
 import { setFilteredCount } from "../store/actions";
+import { deriveListData } from "../helpers/helpers";
 import { markVisible } from "../helpers/filter";
 import { groupByProperty } from "../helpers/groupByProperty";
 import { PanelList } from "./PanelList";
@@ -57,12 +58,14 @@ function sortItemsArray(
 
 export function List(): React.JSX.Element {
   const filter = useAppStore(selectFilter);
-  const rawListData = useAppStore(selectListData);
+  const rawEntries = useAppStore(selectRawEntries);
   const { hideEmptyPages } = useAppStore(selectSettings);
   const sorting = useAppStore(selectSorting);
   const showPages = useAppStore(selectShowPages);
   const showPinnedOnly = useAppStore(selectShowPinnedOnly);
   const pinnedIds = useAppStore(selectPinnedIds);
+
+  const rawListData = useMemo(() => deriveListData(rawEntries), [rawEntries]);
 
   const rawListPinned =
     showPinnedOnly && pinnedIds.size > 0

--- a/apps/web/app/helpers/helpers.ts
+++ b/apps/web/app/helpers/helpers.ts
@@ -1,12 +1,73 @@
-export function prepareFooter(data: any): any {
-  if (!data) {
-    return null;
+import { TabCode } from "../store/store";
+
+export function deriveListData(entries: any[]): any[] {
+  if (!Array.isArray(entries)) return [];
+
+  return entries.map((entry: any, index: number) => {
+    const { pageref, startedDateTime, time, request, response } = entry;
+    const { method, url } = request;
+    const { status, statusText } = response;
+    return { $$id: index, pageref, status, statusText, url, method, startedDateTime, time };
+  });
+}
+
+export function deriveCommonData(entry: any): any {
+  if (!entry) return null;
+
+  const { request, response, serverIPAddress, time, _securityState } = entry;
+  const { method, url, httpVersion } = request;
+  const { status, statusText } = response;
+
+  return { status, statusText, url, method, serverIPAddress, time, httpVersion, _securityState };
+}
+
+export function deriveTabData(entry: any, tabCode: TabCode): any {
+  if (!entry) return null;
+
+  const { request, response, timings } = entry;
+
+  if (tabCode === "REQ") {
+    return {
+      headers: request?.headers,
+      headersSize: request?.headersSize,
+      bodySize: request?.bodySize,
+      content: request?.postData?.text,
+    };
   }
 
-  const { version, creator, entries } = data;
+  if (tabCode === "RES") {
+    return {
+      headers: response?.headers,
+      headersSize: response?.headersSize,
+      bodySize: response?.bodySize,
+      content: response?.content?.text,
+    };
+  }
+
+  if (tabCode === "COO") {
+    return {
+      cookies: {
+        request: request?.cookies,
+        response: response?.cookies,
+      },
+    };
+  }
+
+  if (tabCode === "TIM") {
+    return { timings };
+  }
+
+  return null;
+}
+
+export function deriveFooterData(harData: any, fileSize: number): any {
+  if (!harData) return null;
+
+  const { version, creator, entries } = harData;
 
   return {
     version,
+    fileSize,
     creatorName: creator?.name,
     creatorVersion: creator?.version,
     entriesNum: entries?.length || 0,

--- a/apps/web/app/store/selectors.ts
+++ b/apps/web/app/store/selectors.ts
@@ -1,4 +1,4 @@
-import { AppState, TabCode } from "./store";
+import { AppState } from "./store";
 
 export const selectTab = (state: AppState) => state.ui.tab;
 export const selectFiles = (state: AppState) => state.files;
@@ -44,6 +44,16 @@ export const selectFile = (state: AppState) => {
 export const selectHarData = (state: AppState) =>
   selectFile(state)?.data?.log || null;
 
+export const selectRawEntries = (state: AppState) =>
+  selectFile(state)?.data?.log?.entries ?? null;
+
+export const selectRawEntry = (state: AppState) => {
+  const entries = selectFile(state)?.data?.log?.entries;
+  const rowId = state.ui.rowId;
+  if (!Array.isArray(entries) || rowId == null) return null;
+  return entries[rowId] ?? null;
+};
+
 export const selectEntriesNum = (store: AppState) => {
   const entries = selectFile(store)?.data?.log?.entries;
   return (Array.isArray(entries) && entries.length) || 0;
@@ -67,120 +77,9 @@ export const selectFileEntries = (state: AppState) => {
 export const selectFileTabs = (state: AppState) =>
   selectFiles(state).map(({ fileId, name }) => ({ fileId, name }));
 
-export function selectFooterData(state: AppState) {
-  const harData = selectHarData(state);
-  const fileSize = selectFileSize(state);
-
-  if (!harData) {
-    return null;
-  }
-
-  const { version, creator, entries } = harData;
-
-  return {
-    version,
-    fileSize,
-    creatorName: creator?.name,
-    creatorVersion: creator?.version,
-    entriesNum: entries?.length || 0,
-    totalTime: (
-      entries?.reduce((acc: number, entry: any) => acc + entry.time, 0) || 0
-    ).toFixed(2),
-  };
-}
-
 export function selectEntry(state: AppState) {
   const entries = selectFileEntries(state);
   const rowId = selectRowId(state);
 
   return entries.find((entry: any) => entry.$$id === rowId);
-}
-
-export function selectListData(state: AppState): any {
-  const entries = selectFileEntries(state);
-
-  return entries.map((entry: any) => {
-    const { pageref, startedDateTime, time, request, response, $$id } = entry;
-    const { method, url } = request;
-    const { status, statusText } = response;
-
-    return {
-      $$id,
-      pageref,
-      status,
-      statusText,
-      url,
-      method,
-      startedDateTime,
-      time,
-    };
-  });
-}
-
-export function selectCommonData(state: AppState): any {
-  const entry = selectEntry(state);
-
-  if (!entry) {
-    return null;
-  }
-
-  const { request, response, serverIPAddress, time, _securityState } = entry;
-  const { method, url, httpVersion } = request;
-  const { status, statusText } = response;
-
-  return {
-    status,
-    statusText,
-    url,
-    method,
-    serverIPAddress,
-    time,
-    httpVersion,
-    _securityState,
-  };
-}
-
-export function selectTabData(tabCode: TabCode): any {
-  return (state: AppState) => {
-    const entry = selectEntry(state);
-
-    if (!entry) {
-      return null;
-    }
-
-    const { request, response, timings } = entry;
-
-    if (tabCode === "REQ") {
-      return {
-        headers: request?.headers,
-        headersSize: request?.headersSize,
-        bodySize: request?.bodySize,
-        content: request?.postData?.text,
-      };
-    }
-
-    if (tabCode === "RES") {
-      return {
-        headers: response?.headers,
-        headersSize: response?.headersSize,
-        bodySize: response?.bodySize,
-        content: response?.content?.text,
-      };
-    }
-
-    if (tabCode === "COO") {
-      return {
-        cookies: {
-          request: request?.cookies,
-          response: response?.cookies,
-        },
-      };
-    }
-
-    if (tabCode === "TIM") {
-      return { timings };
-    }
-
-    return null;
-  };
 }


### PR DESCRIPTION
## Summary

- Selectors that built new objects/arrays on every call (`selectTabData`, `selectCommonData`, `selectListData`, `selectFooterData`) caused `useSyncExternalStore` (Zustand v5) to detect perpetual state changes and trigger infinite re-render loops
- Replaced them with stable primitive selectors (`selectRawEntry`, `selectRawEntries`) and pure `derive*` helper functions in `helpers.ts`, called via `useMemo` in components
- Added `useShallow` where `selectEntry` and `selectFiles` return new object/array references with unchanged content
- Removed dead code: `prepareFooter`, `selectFooterData`, `selectCommonData`, `selectListData`, `selectTabData`

## Test plan

- [ ] Open a HAR file and verify the list renders correctly
- [ ] Select a row and verify REQ / RES / COO / TIM tabs all show correct data
- [ ] Verify footer shows correct entry count, total time, file size, and creator info
- [ ] Toggle filter and pinned-only view, verify list updates correctly
- [ ] Switch between multiple loaded files via file tabs
- [ ] Check browser console for any infinite loop or render warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)