### PR TITLE
Fix ...Hide button overlap and left-drift on resize (issue #12)

### DIFF
--- a/packages/ui/src/expand-button.tsx
+++ b/packages/ui/src/expand-button.tsx
@@ -1,26 +1,33 @@
+import { forwardRef } from "react";
 import type React from "react";
 
-export const ExpandButton = ({
-  inline = true,
-  classes = "dark:bg-black bg-white",
-  handleClick,
-  children,
-}: {
-  inline?: boolean;
-  classes?: string;
-  handleClick: () => void;
-  children: React.ReactNode;
-}): React.JSX.Element => {
-  const display = inline
-    ? "absolute bottom-0 right-0 inline"
-    : "static flex items-end";
+export const ExpandButton = forwardRef<
+  HTMLButtonElement,
+  {
+    inline?: boolean;
+    classes?: string;
+    handleClick: () => void;
+    children: React.ReactNode;
+  }
+>(
+  (
+    { inline = true, classes = "dark:bg-black bg-white", handleClick, children },
+    ref,
+  ) => {
+    const display = inline
+      ? "absolute bottom-0 right-0 inline"
+      : "static flex items-end";
 
-  return (
-    <button
-      onClick={() => handleClick()}
-      className={`${display} ${classes} dark:text-accent-300 dark:bg-bunker-500 hover:dark:text-accent-100 text-accent-600 hover:text-accent-800 select-none rounded-sm pl-2 text-[90%] uppercase transition-colors duration-200`}
-    >
-      {children}
-    </button>
-  );
-};
+    return (
+      <button
+        ref={ref}
+        onClick={() => handleClick()}
+        className={`${display} ${classes} dark:text-accent-300 dark:bg-bunker-500 hover:dark:text-accent-100 text-accent-600 hover:text-accent-800 select-none rounded-sm pl-2 text-[90%] uppercase transition-colors duration-200`}
+      >
+        {children}
+      </button>
+    );
+  },
+);
+
+ExpandButton.displayName = "ExpandButton";

--- a/packages/ui/src/line-clamp.tsx
+++ b/packages/ui/src/line-clamp.tsx
@@ -28,7 +28,24 @@ export function LineClamp({
   children: React.ReactNode;
 }): React.JSX.Element {
   if (!active) return <>{children}</>;
+  return (
+    <LineClampInner lines={lines} label={label} classes={classes}>
+      {children}
+    </LineClampInner>
+  );
+}
 
+function LineClampInner({
+  lines,
+  label,
+  classes,
+  children,
+}: {
+  lines: number;
+  label: string;
+  classes?: string;
+  children: React.ReactNode;
+}): React.JSX.Element {
   const [collapsedRef, isCollapsed] = useCollapsed();
   const [expanded, setExpanded] = useState(false);
   const { containerRef, buttonRef, buttonFits } = useButtonFits(expanded);

--- a/packages/ui/src/line-clamp.tsx
+++ b/packages/ui/src/line-clamp.tsx
@@ -1,6 +1,7 @@
 import type React from "react";
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { useCollapsed } from "./use-collapsed";
+import { useButtonFits } from "./use-button-fits";
 import { ExpandButton } from "./expand-button";
 
 const lineClampClassMap: { [key: number]: string } = {
@@ -17,38 +18,53 @@ export function LineClamp({
   lines = 3,
   label = "...More",
   classes,
-  inline = true,
   active = true,
   children,
 }: {
   lines?: number;
   label?: string;
   classes?: string;
-  inline?: boolean;
-  isOpen?: boolean;
   active?: boolean;
   children: React.ReactNode;
 }): React.JSX.Element {
   if (!active) return <>{children}</>;
 
-  const [ref, isCollapsed] = useCollapsed();
+  const [collapsedRef, isCollapsed] = useCollapsed();
   const [expanded, setExpanded] = useState(false);
+  const { containerRef, buttonRef, buttonFits } = useButtonFits(expanded);
+
+  const setRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      collapsedRef(node);
+      containerRef.current = node;
+    },
+    [collapsedRef, containerRef],
+  );
 
   const handleClick = () => setExpanded(!expanded);
 
+  const buttonInline = !expanded || buttonFits !== false;
+
   const button = (
-    <ExpandButton inline={inline} classes={classes} handleClick={handleClick}>
+    <ExpandButton
+      ref={buttonRef}
+      inline={buttonInline}
+      classes={classes}
+      handleClick={handleClick}
+    >
       {expanded ? "...Hide" : label}
     </ExpandButton>
   );
 
   return (
     <div
-      ref={ref}
+      ref={setRef}
       className={`relative ${lineClampClassMap[expanded ? 0 : lines]}`}
     >
       {children}
-      {isCollapsed ? button : null}
+      {expanded || isCollapsed ? (
+        buttonInline ? button : <div className="flex justify-end">{button}</div>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Wires up the existing `useButtonFits` hook (was written but never connected) to detect when the last text line is too wide to fit the `...Hide` button inline
- Wraps the button in `flex justify-end` when it needs to break to its own line, so it always stays on the right side of the container
- Fixes `...Hide` button disappearing on expand by showing it unconditionally when `expanded=true`, not just when `isCollapsed=true`

Closes #12

## Test plan

- [ ] Expand a field whose last line fills the full container width — `...Hide` should appear below the text, right-aligned
- [ ] Expand a field whose last line is short — `...Hide` should appear inline at the end of the text
- [ ] Resize the browser window while expanded — button should stay right-aligned and never jump to the left
- [ ] Collapse via `...Hide` — content should clamp back and `...More` should reappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)