### PR TITLE
feat(test): Vitest unit tests for apps/web pure helpers

### DIFF
--- a/apps/web/app/core/helpers/formatDateTime.test.ts
+++ b/apps/web/app/core/helpers/formatDateTime.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { formatDateTime, leadingZero } from "./formatDateTime";
+
+describe("leadingZero", () => {
+  it("pads single-digit numbers", () => {
+    expect(leadingZero(0)).toBe("00");
+    expect(leadingZero(9)).toBe("09");
+  });
+
+  it("does not pad two-digit numbers", () => {
+    expect(leadingZero(10)).toBe("10");
+    expect(leadingZero(59)).toBe("59");
+  });
+});
+
+describe("formatDateTime", () => {
+  it("formats a full date-time string", () => {
+    const result = formatDateTime("2024-03-15T14:05:06.789Z");
+    expect(result).toMatch(/^\d{2}\.\d{2}\.\d{4} \d+:\d{2}:\d{2}\.\d+$/);
+  });
+
+  it("returns time-only format when timeOnly is true", () => {
+    const result = formatDateTime("2024-03-15T14:05:06.789Z", true);
+    expect(result).toMatch(/^\d+:\d{2}:\d{2}\.\d+$/);
+  });
+
+  it("time-only result omits the date portion", () => {
+    const full = formatDateTime("2024-03-15T14:05:06.789Z", false);
+    const timeOnly = formatDateTime("2024-03-15T14:05:06.789Z", true);
+    expect(full.length).toBeGreaterThan(timeOnly.length);
+    expect(full).toContain(timeOnly);
+  });
+});

--- a/apps/web/app/core/helpers/formatFileSize.test.ts
+++ b/apps/web/app/core/helpers/formatFileSize.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { formatFileSize } from "./formatFileSize";
+
+describe("formatFileSize", () => {
+  it("formats bytes", () => {
+    expect(formatFileSize(0)).toBe("0 B");
+    expect(formatFileSize(500)).toBe("500 B");
+    expect(formatFileSize(1023)).toBe("1023 B");
+  });
+
+  it("formats kilobytes", () => {
+    expect(formatFileSize(1024)).toBe("1 kB");
+    expect(formatFileSize(2048)).toBe("2 kB");
+    expect(formatFileSize(5120)).toBe("5 kB");
+    expect(formatFileSize(10240)).toBe("10 kB");
+  });
+
+  it("formats megabytes", () => {
+    expect(formatFileSize(1048576)).toBe("1 MB");
+    expect(formatFileSize(5 * 1048576)).toBe("5 MB");
+  });
+
+  it("returns N/A for negative values", () => {
+    expect(formatFileSize(-1)).toBe("N/A");
+  });
+
+  it("returns N/A for non-finite values", () => {
+    expect(formatFileSize(Infinity)).toBe("N/A");
+    expect(formatFileSize(NaN)).toBe("N/A");
+  });
+});

--- a/apps/web/app/core/helpers/formatNumber.test.ts
+++ b/apps/web/app/core/helpers/formatNumber.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { formatNumber } from "./formatNumber";
+
+describe("formatNumber", () => {
+  it("formats numbers below 1000 without separator", () => {
+    expect(formatNumber(0)).toBe("0");
+    expect(formatNumber(999)).toBe("999");
+  });
+
+  it("inserts spaces as thousands separator", () => {
+    expect(formatNumber(1000)).toBe("1 000");
+    expect(formatNumber(1000000)).toBe("1 000 000");
+    expect(formatNumber(123456789)).toBe("123 456 789");
+  });
+
+  it("works with negative numbers", () => {
+    expect(formatNumber(-1000)).toBe("-1 000");
+  });
+});

--- a/apps/web/app/core/helpers/getUrlParts.test.ts
+++ b/apps/web/app/core/helpers/getUrlParts.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { getUrlParts } from "./getUrlParts";
+
+describe("getUrlParts", () => {
+  it("parses a simple URL", () => {
+    const result = getUrlParts("https://example.com/path");
+    expect(result.protocol).toBe("https:");
+    expect(result.domain).toBe("example.com");
+    expect(result.path).toBe("/path");
+    expect(result.port).toBe("");
+    expect(result.params).toBe("");
+    expect(result.hash).toBe("");
+  });
+
+  it("parses a URL with query params and hash", () => {
+    const result = getUrlParts("https://example.com/search?q=hello&page=2#results");
+    expect(result.params).toBe("?q=hello&page=2");
+    expect(result.hash).toBe("#results");
+  });
+
+  it("parses a URL with a custom port", () => {
+    const result = getUrlParts("http://localhost:3000/api");
+    expect(result.domain).toBe("localhost");
+    expect(result.port).toBe("3000");
+    expect(result.path).toBe("/api");
+  });
+});

--- a/apps/web/app/features/detail/helpers/deriveCommonData.test.ts
+++ b/apps/web/app/features/detail/helpers/deriveCommonData.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { deriveCommonData } from "./deriveCommonData";
+
+const makeEntry = (overrides = {}) => ({
+  request: { method: "GET", url: "https://example.com/api", httpVersion: "HTTP/1.1" },
+  response: { status: 200, statusText: "OK" },
+  serverIPAddress: "93.184.216.34",
+  time: 123.45,
+  _securityState: "secure",
+  ...overrides,
+});
+
+describe("deriveCommonData", () => {
+  it("returns null for falsy input", () => {
+    expect(deriveCommonData(null)).toBeNull();
+    expect(deriveCommonData(undefined)).toBeNull();
+  });
+
+  it("extracts expected fields from a valid entry", () => {
+    const result = deriveCommonData(makeEntry());
+    expect(result).toEqual({
+      status: 200,
+      statusText: "OK",
+      url: "https://example.com/api",
+      method: "GET",
+      serverIPAddress: "93.184.216.34",
+      time: 123.45,
+      httpVersion: "HTTP/1.1",
+      _securityState: "secure",
+    });
+  });
+
+  it("passes through undefined optional fields", () => {
+    const entry = makeEntry();
+    delete (entry as any).serverIPAddress;
+    const result = deriveCommonData(entry);
+    expect(result.serverIPAddress).toBeUndefined();
+  });
+});

--- a/apps/web/app/features/footer/helpers/deriveFooterData.test.ts
+++ b/apps/web/app/features/footer/helpers/deriveFooterData.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { deriveFooterData } from "./deriveFooterData";
+
+const makeHar = (overrides = {}) => ({
+  version: "1.2",
+  creator: { name: "Chrome", version: "120" },
+  entries: [{ time: 100 }, { time: 200 }, { time: 50 }],
+  ...overrides,
+});
+
+describe("deriveFooterData", () => {
+  it("returns null when harData is falsy", () => {
+    expect(deriveFooterData(null, 0)).toBeNull();
+    expect(deriveFooterData(undefined, 0)).toBeNull();
+  });
+
+  it("extracts version, creator, and entry count", () => {
+    const result = deriveFooterData(makeHar(), 1024);
+    expect(result.version).toBe("1.2");
+    expect(result.creatorName).toBe("Chrome");
+    expect(result.creatorVersion).toBe("120");
+    expect(result.entriesNum).toBe(3);
+    expect(result.fileSize).toBe(1024);
+  });
+
+  it("computes total time as a fixed-2 string", () => {
+    const result = deriveFooterData(makeHar(), 0);
+    expect(result.totalTime).toBe("350.00");
+  });
+
+  it("returns 0 entries and 0 total time when entries is missing", () => {
+    const result = deriveFooterData(makeHar({ entries: undefined }), 0);
+    expect(result.entriesNum).toBe(0);
+    expect(result.totalTime).toBe("0.00");
+  });
+});

--- a/apps/web/app/features/list/helpers/filter.test.ts
+++ b/apps/web/app/features/list/helpers/filter.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { markVisible } from "./filter";
+
+const makeFilter = (fields = {}) => ({
+  visible: true,
+  active: true,
+  count: 0,
+  fields: { url: "", method: "", status: "", ...fields },
+});
+
+const makeItem = (overrides = {}) => ({
+  url: "https://example.com/api/users",
+  method: "GET",
+  status: "200",
+  ...overrides,
+});
+
+describe("markVisible", () => {
+  it("marks all items visible when filter fields are empty", () => {
+    const mark = markVisible(makeFilter());
+    const result = mark(makeItem());
+    expect(result.$$visible).toBe(true);
+    expect(result.$$hidden).toBe(false);
+  });
+
+  it("marks item visible when it matches the filter", () => {
+    const mark = markVisible(makeFilter({ url: "users" }));
+    expect(mark(makeItem()).$$visible).toBe(true);
+  });
+
+  it("marks item hidden when it does not match the filter", () => {
+    const mark = markVisible(makeFilter({ url: "posts" }));
+    expect(mark(makeItem()).$$visible).toBe(false);
+    expect(mark(makeItem()).$$hidden).toBe(true);
+  });
+
+  it("supports negative token (prefixed with -)", () => {
+    const mark = markVisible(makeFilter({ url: "-posts" }));
+    expect(mark(makeItem()).$$visible).toBe(true);
+    expect(mark(makeItem({ url: "https://example.com/posts" })).$$visible).toBe(false);
+  });
+
+  it("supports multiple tokens in one field (AND logic)", () => {
+    const mark = markVisible(makeFilter({ url: "example users" }));
+    expect(mark(makeItem()).$$visible).toBe(true);
+    expect(mark(makeItem({ url: "https://other.com/users" })).$$visible).toBe(false);
+  });
+
+  it("matches across multiple fields simultaneously", () => {
+    const mark = markVisible(makeFilter({ url: "users", method: "GET" }));
+    expect(mark(makeItem()).$$visible).toBe(true);
+    expect(mark(makeItem({ method: "POST" })).$$visible).toBe(false);
+  });
+});

--- a/apps/web/app/features/list/helpers/groupByProperty.test.ts
+++ b/apps/web/app/features/list/helpers/groupByProperty.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { groupByProperty } from "./groupByProperty";
+
+describe("groupByProperty", () => {
+  it("returns an empty array for empty input", () => {
+    expect(groupByProperty([], "pageref")).toEqual([]);
+  });
+
+  it("groups consecutive items with the same property value", () => {
+    const items = [
+      { pageref: "page_1", url: "a" },
+      { pageref: "page_1", url: "b" },
+      { pageref: "page_2", url: "c" },
+    ];
+    const result = groupByProperty(items, "pageref");
+    expect(result).toHaveLength(2);
+    expect(result[0]).toHaveLength(2);
+    expect(result[1]).toHaveLength(1);
+  });
+
+  it("does not group non-consecutive items with the same value", () => {
+    const items = [
+      { pageref: "page_1", url: "a" },
+      { pageref: "page_2", url: "b" },
+      { pageref: "page_1", url: "c" },
+    ];
+    const result = groupByProperty(items, "pageref");
+    expect(result).toHaveLength(3);
+  });
+
+  it("puts each item in its own group when all values differ", () => {
+    const items = [
+      { pageref: "a" },
+      { pageref: "b" },
+      { pageref: "c" },
+    ];
+    const result = groupByProperty(items, "pageref");
+    expect(result).toHaveLength(3);
+    result.forEach((group) => expect(group).toHaveLength(1));
+  });
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint . --max-warnings 0"
+    "lint": "eslint . --max-warnings 0",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@repo/formatter-core": "*",
@@ -34,6 +36,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "eslint": "^8.57.0",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "vitest": "^4.1.5"
   }
 }

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    globals: true,
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -130,7 +130,8 @@
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "eslint": "^8.57.0",
-        "typescript": "^5.3.3"
+        "typescript": "^5.3.3",
+        "vitest": "^4.1.5"
       }
     },
     "apps/web/node_modules/@next/eslint-plugin-next": {
@@ -10933,7 +10934,8 @@
         "@types/react": "^19.2.14",
         "eslint": "^8.57.0",
         "react": "^19.2.5",
-        "typescript": "^5.3.3"
+        "typescript": "^5.3.3",
+        "vitest": "^4.1.5"
       }
     },
     "packages/formatter-core/node_modules/@types/node": {


### PR DESCRIPTION
## Summary
- Add `vitest.config.ts` with node environment and globals enabled
- Add `test` and `test:watch` scripts + `vitest` dev dependency to `apps/web/package.json`
- Add unit tests (33 tests across 8 files) covering:
  - Core helpers: `formatFileSize`, `formatDateTime`, `formatNumber`, `getUrlParts`
  - Feature helpers: `deriveCommonData`, `markVisible` (filter), `groupByProperty`, `deriveFooterData`

Closes #26

Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>