### PR TITLE
feat(test): Vitest component tests for all plugin packages (issue #29)

### DIFF
--- a/apps/docs/next-env.d.ts
+++ b/apps/docs/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4367,20 +4367,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
@@ -9164,6 +9150,20 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/pretty-format/node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -12671,12 +12671,16 @@
       "devDependencies": {
         "@repo/eslint-config": "*",
         "@repo/typescript-config": "*",
+        "@testing-library/jest-dom": "^6.6.3",
+        "@testing-library/react": "^16.3.0",
         "@types/eslint": "^8.56.5",
         "@types/node": "^20.11.24",
         "@types/react": "^19.2.14",
         "eslint": "^8.57.0",
+        "jsdom": "^26.0.0",
         "react": "^19.2.5",
-        "typescript": "^5.3.3"
+        "typescript": "^5.3.3",
+        "vitest": "^4.1.5"
       }
     },
     "packages/plugin-headers-plain/node_modules/@types/node": {
@@ -12700,12 +12704,16 @@
       "devDependencies": {
         "@repo/eslint-config": "*",
         "@repo/typescript-config": "*",
+        "@testing-library/jest-dom": "^6.6.3",
+        "@testing-library/react": "^16.3.0",
         "@types/eslint": "^8.56.5",
         "@types/node": "^20.11.24",
         "@types/react": "^19.2.14",
         "eslint": "^8.57.0",
+        "jsdom": "^26.0.0",
         "react": "^19.2.5",
-        "typescript": "^5.3.3"
+        "typescript": "^5.3.3",
+        "vitest": "^4.1.5"
       }
     },
     "packages/plugin-headers-raw/node_modules/@types/node": {
@@ -12729,12 +12737,16 @@
       "devDependencies": {
         "@repo/eslint-config": "*",
         "@repo/typescript-config": "*",
+        "@testing-library/jest-dom": "^6.6.3",
+        "@testing-library/react": "^16.3.0",
         "@types/eslint": "^8.56.5",
         "@types/node": "^20.11.24",
         "@types/react": "^19.2.14",
         "eslint": "^8.57.0",
+        "jsdom": "^26.0.0",
         "react": "^19.2.5",
-        "typescript": "^5.3.3"
+        "typescript": "^5.3.3",
+        "vitest": "^4.1.5"
       }
     },
     "packages/plugin-headers-table/node_modules/@types/node": {
@@ -12759,12 +12771,16 @@
       "devDependencies": {
         "@repo/eslint-config": "*",
         "@repo/typescript-config": "*",
+        "@testing-library/jest-dom": "^6.6.3",
+        "@testing-library/react": "^16.3.0",
         "@types/eslint": "^8.56.5",
         "@types/node": "^20.11.24",
         "@types/react": "^19.2.14",
         "eslint": "^8.57.0",
+        "jsdom": "^26.0.0",
         "react": "^19.2.5",
-        "typescript": "^5.3.3"
+        "typescript": "^5.3.3",
+        "vitest": "^4.1.5"
       }
     },
     "packages/plugin-json-pretty/node_modules/@types/node": {
@@ -12788,12 +12804,16 @@
       "devDependencies": {
         "@repo/eslint-config": "*",
         "@repo/typescript-config": "*",
+        "@testing-library/jest-dom": "^6.6.3",
+        "@testing-library/react": "^16.3.0",
         "@types/eslint": "^8.56.5",
         "@types/node": "^20.11.24",
         "@types/react": "^19.2.14",
         "eslint": "^8.57.0",
+        "jsdom": "^26.0.0",
         "react": "^19.2.5",
-        "typescript": "^5.3.3"
+        "typescript": "^5.3.3",
+        "vitest": "^4.1.5"
       }
     },
     "packages/plugin-json-raw/node_modules/@types/node": {
@@ -12818,13 +12838,17 @@
       "devDependencies": {
         "@repo/eslint-config": "*",
         "@repo/typescript-config": "*",
+        "@testing-library/jest-dom": "^6.6.3",
+        "@testing-library/react": "^16.3.0",
         "@types/eslint": "^8.56.5",
         "@types/node": "^20.11.24",
         "@types/react": "^19.2.14",
         "@types/ua-parser-js": "^0.7.39",
         "eslint": "^8.57.0",
+        "jsdom": "^26.0.0",
         "react": "^19.2.5",
-        "typescript": "^5.3.3"
+        "typescript": "^5.3.3",
+        "vitest": "^4.1.5"
       }
     },
     "packages/plugin-user-agent-parse/node_modules/@types/node": {
@@ -12847,12 +12871,16 @@
       "devDependencies": {
         "@repo/eslint-config": "*",
         "@repo/typescript-config": "*",
+        "@testing-library/jest-dom": "^6.6.3",
+        "@testing-library/react": "^16.3.0",
         "@types/eslint": "^8.56.5",
         "@types/node": "^20.11.24",
         "@types/react": "^19.2.14",
         "eslint": "^8.57.0",
+        "jsdom": "^26.0.0",
         "react": "^19.2.5",
-        "typescript": "^5.3.3"
+        "typescript": "^5.3.3",
+        "vitest": "^4.1.5"
       }
     },
     "packages/plugin-user-agent-raw/node_modules/@types/node": {

--- a/packages/formatter-core/package.json
+++ b/packages/formatter-core/package.json
@@ -7,7 +7,9 @@
     "./registry": "./src/registry.ts"
   },
   "scripts": {
-    "lint": "eslint . --max-warnings 0"
+    "lint": "eslint . --max-warnings 0",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "devDependencies": {
     "@repo/eslint-config": "*",
@@ -17,7 +19,8 @@
     "@types/react": "^19.2.14",
     "eslint": "^8.57.0",
     "react": "^19.2.5",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "vitest": "^4.1.5"
   },
   "dependencies": {
     "react-dom": "^19.2.5"

--- a/packages/formatter-core/src/Formatter.test.ts
+++ b/packages/formatter-core/src/Formatter.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import type { Formatter } from "./Formatter";
+
+describe("Formatter – type shape and field validation", () => {
+  it("accepts a fully constructed formatter object", () => {
+    const formatter: Formatter<string> = {
+      id: "plain",
+      title: "Plain Text",
+      icon: "mdi:text",
+      tooltip: "Display as plain text",
+      format: (data) => data,
+    };
+
+    expect(formatter.id).toBe("plain");
+    expect(formatter.title).toBe("Plain Text");
+    expect(formatter.icon).toBe("mdi:text");
+    expect(formatter.tooltip).toBe("Display as plain text");
+  });
+
+  it("format function returns the data it receives", () => {
+    const formatter: Formatter<string> = {
+      id: "echo",
+      title: "Echo",
+      icon: "mdi:echo",
+      tooltip: "",
+      format: (data) => data,
+    };
+
+    expect(formatter.format("hello")).toBe("hello");
+  });
+
+  it("format function can return null", () => {
+    const formatter: Formatter<string> = {
+      id: "null-fmt",
+      title: "Null",
+      icon: "",
+      tooltip: "",
+      format: () => null,
+    };
+
+    expect(formatter.format("anything")).toBeNull();
+  });
+
+  it("works with a numeric data type", () => {
+    const formatter: Formatter<number> = {
+      id: "num",
+      title: "Number",
+      icon: "mdi:number",
+      tooltip: "Formats numbers",
+      format: (n) => String(n),
+    };
+
+    expect(formatter.format(42)).toBe("42");
+  });
+});

--- a/packages/formatter-core/src/FormatterProvider.test.ts
+++ b/packages/formatter-core/src/FormatterProvider.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { FormatterProvider } from "./FormatterProvider";
+
+type Item = { id: string; name: string };
+
+describe("FormatterProvider – registration and retrieval", () => {
+  it("returns indexes as a string when a single formatter is added", () => {
+    const provider = FormatterProvider<Item>();
+    const result = provider.addFormatters("xml", { id: "x1", name: "X1" });
+    expect(result).toBe("x1");
+  });
+
+  it("returns indexes as an array when multiple formatters are added", () => {
+    const provider = FormatterProvider<Item>();
+    const result = provider.addFormatters("xml", [
+      { id: "x1", name: "X1" },
+      { id: "x2", name: "X2" },
+    ]);
+    expect(result).toEqual(["x1", "x2"]);
+  });
+
+  it("overwrites a formatter registered under the same id", () => {
+    const provider = FormatterProvider<Item>();
+    provider.addFormatters("key", { id: "f1", name: "Old" });
+    provider.addFormatters("key", { id: "f1", name: "New" });
+    expect(provider.getFormatter("key", "f1")).toEqual({ id: "f1", name: "New" });
+  });
+
+  it("getFormatters returns all formatters for a key", () => {
+    const provider = FormatterProvider<Item>();
+    provider.addFormatters("key", [
+      { id: "a", name: "A" },
+      { id: "b", name: "B" },
+    ]);
+    const all = provider.getFormatters("key");
+    expect(all).toEqual({
+      a: { id: "a", name: "A" },
+      b: { id: "b", name: "B" },
+    });
+  });
+
+  it("getFormatter with empty id returns null", () => {
+    const provider = FormatterProvider<Item>();
+    provider.addFormatters("key", { id: "f1", name: "F1" });
+    expect(provider.getFormatter("key", "")).toBeNull();
+  });
+
+  it("uses case-insensitive matching as the default", () => {
+    const provider = FormatterProvider<Item>();
+    provider.addFormatters("Content-Type", { id: "ct", name: "CT" });
+    expect(provider.getFormatters("content-type")).not.toBeNull();
+    expect(provider.getFormatters("CONTENT-TYPE")).not.toBeNull();
+  });
+
+  it("falls back to null when formatter key is absent", () => {
+    const provider = FormatterProvider<Item>();
+    expect(provider.getDefaultFormatter("nope")).toBeNull();
+  });
+});

--- a/packages/formatter-core/src/registry.test.ts
+++ b/packages/formatter-core/src/registry.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { FormatterProvider } from "./FormatterProvider";
+
+type TestFormatter = { id: string; label: string };
+
+describe("FormatterProvider – registry basics", () => {
+  let provider: ReturnType<typeof FormatterProvider<TestFormatter>>;
+
+  beforeEach(() => {
+    provider = FormatterProvider<TestFormatter>();
+  });
+
+  it("adds a single formatter and retrieves it", () => {
+    provider.addFormatters("json", { id: "f1", label: "F1" });
+    const result = provider.getFormatter("json", "f1");
+    expect(result).toEqual({ id: "f1", label: "F1" });
+  });
+
+  it("adds multiple formatters at once", () => {
+    provider.addFormatters("json", [
+      { id: "f1", label: "F1" },
+      { id: "f2", label: "F2" },
+    ]);
+    expect(provider.getFormatter("json", "f1")).toEqual({ id: "f1", label: "F1" });
+    expect(provider.getFormatter("json", "f2")).toEqual({ id: "f2", label: "F2" });
+  });
+
+  it("returns null for a key that was never added", () => {
+    expect(provider.getFormatters("missing")).toBeNull();
+  });
+
+  it("returns null for an id that was never added", () => {
+    provider.addFormatters("json", { id: "f1", label: "F1" });
+    expect(provider.getFormatter("json", "unknown")).toBeNull();
+  });
+
+  it("removes a specific formatter by id", () => {
+    provider.addFormatters("json", [
+      { id: "f1", label: "F1" },
+      { id: "f2", label: "F2" },
+    ]);
+    provider.removeFormatter("json", "f1");
+    expect(provider.getFormatter("json", "f1")).toBeNull();
+    expect(provider.getFormatter("json", "f2")).toEqual({ id: "f2", label: "F2" });
+  });
+
+  it("removes all formatters for a key when no id given", () => {
+    provider.addFormatters("json", { id: "f1", label: "F1" });
+    provider.removeFormatter("json");
+    expect(provider.getFormatters("json")).toBeNull();
+  });
+
+  it("is case-insensitive by default", () => {
+    provider.addFormatters("JSON", { id: "f1", label: "F1" });
+    expect(provider.getFormatter("json", "f1")).toEqual({ id: "f1", label: "F1" });
+    expect(provider.getFormatter("JSON", "f1")).toEqual({ id: "f1", label: "F1" });
+    expect(provider.getFormatter("Json", "f1")).toEqual({ id: "f1", label: "F1" });
+  });
+
+  it("is case-sensitive when configured", () => {
+    const cs = FormatterProvider<TestFormatter>({ comparativeMethod: "case-sensitive" });
+    cs.addFormatters("JSON", { id: "f1", label: "F1" });
+    expect(cs.getFormatter("JSON", "f1")).toEqual({ id: "f1", label: "F1" });
+    expect(cs.getFormatter("json", "f1")).toBeNull();
+  });
+
+  it("getDefaultFormatter returns first registered entry", () => {
+    provider.addFormatters("json", [
+      { id: "f1", label: "F1" },
+      { id: "f2", label: "F2" },
+    ]);
+    const def = provider.getDefaultFormatter("json");
+    expect(def).not.toBeNull();
+    expect(def![0]).toBe("f1");
+    expect(def![1]).toEqual({ id: "f1", label: "F1" });
+  });
+
+  it("getDefaultFormatter returns null for unknown key", () => {
+    expect(provider.getDefaultFormatter("missing")).toBeNull();
+  });
+});

--- a/packages/formatter-core/tsconfig.lint.json
+++ b/packages/formatter-core/tsconfig.lint.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "outDir": "dist"
   },
-  "include": ["src"],
+  "include": ["src", "vitest.config.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/formatter-core/vitest.config.ts
+++ b/packages/formatter-core/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    globals: true,
+  },
+});

--- a/packages/plugin-headers-plain/package.json
+++ b/packages/plugin-headers-plain/package.json
@@ -6,7 +6,9 @@
     ".": "./src/index.tsx"
   },
   "scripts": {
-    "lint": "eslint . --max-warnings 0"
+    "lint": "eslint . --max-warnings 0",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@repo/formatter-core": "*",
@@ -16,11 +18,15 @@
   "devDependencies": {
     "@repo/eslint-config": "*",
     "@repo/typescript-config": "*",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
     "@types/eslint": "^8.56.5",
     "@types/node": "^20.11.24",
     "@types/react": "^19.2.14",
     "eslint": "^8.57.0",
+    "jsdom": "^26.0.0",
     "react": "^19.2.5",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "vitest": "^4.1.5"
   }
 }

--- a/packages/plugin-headers-plain/src/headersPlainFormatter.test.tsx
+++ b/packages/plugin-headers-plain/src/headersPlainFormatter.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { headersPlainFormatter } from "./index";
+
+const sampleHeaders = [
+  { name: "Content-Type", value: "application/json" },
+  { name: "Accept", value: "text/html" },
+];
+
+describe("headersPlainFormatter", () => {
+  it("has correct id and title", () => {
+    expect(headersPlainFormatter.id).toBe("headers-plain-formatter");
+    expect(headersPlainFormatter.title).toBe("Plain");
+  });
+
+  it("renders header names and values", () => {
+    const element = headersPlainFormatter.format(sampleHeaders);
+    const { container } = render(element as ReactElement);
+    expect(container).toHaveTextContent("Content-Type");
+    expect(container).toHaveTextContent("application/json");
+  });
+
+  it("renders all provided headers", () => {
+    const element = headersPlainFormatter.format(sampleHeaders);
+    const { container } = render(element as ReactElement);
+    expect(container).toHaveTextContent("Accept");
+    expect(container).toHaveTextContent("text/html");
+  });
+
+  it("renders empty header list without crashing", () => {
+    const element = headersPlainFormatter.format([]);
+    const { container } = render(element as ReactElement);
+    expect(container.firstChild).toBeTruthy();
+  });
+});

--- a/packages/plugin-headers-plain/test-setup.ts
+++ b/packages/plugin-headers-plain/test-setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom";

--- a/packages/plugin-headers-plain/tsconfig.lint.json
+++ b/packages/plugin-headers-plain/tsconfig.lint.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "outDir": "dist"
   },
-  "include": ["src"],
+  "include": ["src", "vitest.config.ts", "test-setup.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/plugin-headers-plain/vitest.config.ts
+++ b/packages/plugin-headers-plain/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: ["./test-setup.ts"],
+  },
+});

--- a/packages/plugin-headers-raw/package.json
+++ b/packages/plugin-headers-raw/package.json
@@ -6,7 +6,9 @@
     ".": "./src/index.tsx"
   },
   "scripts": {
-    "lint": "eslint . --max-warnings 0"
+    "lint": "eslint . --max-warnings 0",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@repo/formatter-core": "*",
@@ -16,11 +18,15 @@
   "devDependencies": {
     "@repo/eslint-config": "*",
     "@repo/typescript-config": "*",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
     "@types/eslint": "^8.56.5",
     "@types/node": "^20.11.24",
     "@types/react": "^19.2.14",
     "eslint": "^8.57.0",
+    "jsdom": "^26.0.0",
     "react": "^19.2.5",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "vitest": "^4.1.5"
   }
 }

--- a/packages/plugin-headers-raw/src/headersRawFormatter.test.tsx
+++ b/packages/plugin-headers-raw/src/headersRawFormatter.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { HostProvider } from "@repo/formatter-core";
+import { headersRawFormatter } from "./index";
+
+const hostValue = {
+  theme: "light" as const,
+  jsonViewer: {
+    collapsed: 2,
+    indentWidth: 2,
+    enableClipboard: true,
+    displayDataTypes: false,
+    displayObjectSize: false,
+    highlightUpdates: false,
+    shortenTextAfterLength: 0,
+  },
+  notify: () => {},
+};
+
+const sampleHeaders = [{ name: "Content-Type", value: "application/json" }];
+
+describe("headersRawFormatter", () => {
+  it("has correct id and title", () => {
+    expect(headersRawFormatter.id).toBe("headers-raw-formatter");
+    expect(headersRawFormatter.title).toBe("Raw");
+  });
+
+  it("renders inside HostProvider without crashing", () => {
+    const element = headersRawFormatter.format(sampleHeaders);
+    const { container } = render(
+      <HostProvider value={hostValue}>{element}</HostProvider>,
+    );
+    expect(container.firstChild).toBeTruthy();
+  });
+
+  it("renders multiple headers inside HostProvider", () => {
+    const headers = [
+      { name: "Content-Type", value: "application/json" },
+      { name: "Authorization", value: "Bearer token123" },
+    ];
+    const element = headersRawFormatter.format(headers);
+    const { container } = render(
+      <HostProvider value={hostValue}>{element}</HostProvider>,
+    );
+    expect(container.firstChild).toBeTruthy();
+  });
+});

--- a/packages/plugin-headers-raw/test-setup.ts
+++ b/packages/plugin-headers-raw/test-setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom";

--- a/packages/plugin-headers-raw/tsconfig.lint.json
+++ b/packages/plugin-headers-raw/tsconfig.lint.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "outDir": "dist"
   },
-  "include": ["src"],
+  "include": ["src", "vitest.config.ts", "test-setup.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/plugin-headers-raw/vitest.config.ts
+++ b/packages/plugin-headers-raw/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: ["./test-setup.ts"],
+  },
+});

--- a/packages/plugin-headers-table/package.json
+++ b/packages/plugin-headers-table/package.json
@@ -6,7 +6,9 @@
     ".": "./src/index.tsx"
   },
   "scripts": {
-    "lint": "eslint . --max-warnings 0"
+    "lint": "eslint . --max-warnings 0",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@repo/formatter-core": "*",
@@ -16,11 +18,15 @@
   "devDependencies": {
     "@repo/eslint-config": "*",
     "@repo/typescript-config": "*",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
     "@types/eslint": "^8.56.5",
     "@types/node": "^20.11.24",
     "@types/react": "^19.2.14",
     "eslint": "^8.57.0",
+    "jsdom": "^26.0.0",
     "react": "^19.2.5",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "vitest": "^4.1.5"
   }
 }

--- a/packages/plugin-headers-table/src/headersTableFormatter.test.tsx
+++ b/packages/plugin-headers-table/src/headersTableFormatter.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { headersTableFormatter } from "./index";
+
+const sampleHeaders = [
+  { name: "Content-Type", value: "application/json" },
+  { name: "Accept", value: "text/html" },
+];
+
+describe("headersTableFormatter", () => {
+  it("has correct id and title", () => {
+    expect(headersTableFormatter.id).toBe("headers-table-formatter");
+    expect(headersTableFormatter.title).toBe("Table");
+  });
+
+  it("renders header names in table cells", () => {
+    const element = headersTableFormatter.format(sampleHeaders);
+    const { container } = render(element as ReactElement);
+    expect(container).toHaveTextContent("Content-Type");
+    expect(container).toHaveTextContent("Accept");
+  });
+
+  it("renders header values", () => {
+    const element = headersTableFormatter.format(sampleHeaders);
+    const { container } = render(element as ReactElement);
+    expect(container).toHaveTextContent("application/json");
+    expect(container).toHaveTextContent("text/html");
+  });
+
+  it("renders no-content message for empty headers", () => {
+    const element = headersTableFormatter.format([]);
+    const { container } = render(element as ReactElement);
+    expect(container).toHaveTextContent("No Content");
+  });
+});

--- a/packages/plugin-headers-table/test-setup.ts
+++ b/packages/plugin-headers-table/test-setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom";

--- a/packages/plugin-headers-table/tsconfig.lint.json
+++ b/packages/plugin-headers-table/tsconfig.lint.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "outDir": "dist"
   },
-  "include": ["src"],
+  "include": ["src", "vitest.config.ts", "test-setup.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/plugin-headers-table/vitest.config.ts
+++ b/packages/plugin-headers-table/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: ["./test-setup.ts"],
+  },
+});

--- a/packages/plugin-json-pretty/package.json
+++ b/packages/plugin-json-pretty/package.json
@@ -6,7 +6,9 @@
     ".": "./src/index.tsx"
   },
   "scripts": {
-    "lint": "eslint . --max-warnings 0"
+    "lint": "eslint . --max-warnings 0",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@repo/formatter-core": "*",
@@ -17,11 +19,15 @@
   "devDependencies": {
     "@repo/eslint-config": "*",
     "@repo/typescript-config": "*",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
     "@types/eslint": "^8.56.5",
     "@types/node": "^20.11.24",
     "@types/react": "^19.2.14",
     "eslint": "^8.57.0",
+    "jsdom": "^26.0.0",
     "react": "^19.2.5",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "vitest": "^4.1.5"
   }
 }

--- a/packages/plugin-json-pretty/src/jsonPrettyFormatter.test.tsx
+++ b/packages/plugin-json-pretty/src/jsonPrettyFormatter.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { HostProvider } from "@repo/formatter-core";
+import { jsonPrettyFormatter } from "./index";
+
+const hostValue = {
+  theme: "light" as const,
+  jsonViewer: {
+    collapsed: 2,
+    indentWidth: 2,
+    enableClipboard: true,
+    displayDataTypes: false,
+    displayObjectSize: false,
+    highlightUpdates: false,
+    shortenTextAfterLength: 0,
+  },
+  notify: () => {},
+};
+
+describe("jsonPrettyFormatter", () => {
+  it("has correct id and title", () => {
+    expect(jsonPrettyFormatter.id).toBe("json-pretty-formatter");
+    expect(jsonPrettyFormatter.title).toBe("Pretty");
+  });
+
+  it("renders plain text content for non-JSON value", () => {
+    const element = jsonPrettyFormatter.format({ value: "plain text content" });
+    const { container } = render(element as ReactElement);
+    expect(container).toHaveTextContent("plain text content");
+  });
+
+  it("renders null value as empty string", () => {
+    const element = jsonPrettyFormatter.format({ value: null });
+    const { container } = render(element as ReactElement);
+    expect(container.firstChild).toBeTruthy();
+  });
+
+  it("renders valid JSON inside HostProvider", () => {
+    const json = JSON.stringify({ status: "ok", count: 42 });
+    const element = jsonPrettyFormatter.format({ value: json });
+    const { container } = render(
+      <HostProvider value={hostValue}>{element}</HostProvider>,
+    );
+    expect(container.firstChild).toBeTruthy();
+  });
+});

--- a/packages/plugin-json-pretty/test-setup.ts
+++ b/packages/plugin-json-pretty/test-setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom";

--- a/packages/plugin-json-pretty/tsconfig.lint.json
+++ b/packages/plugin-json-pretty/tsconfig.lint.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "outDir": "dist"
   },
-  "include": ["src"],
+  "include": ["src", "vitest.config.ts", "test-setup.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/plugin-json-pretty/vitest.config.ts
+++ b/packages/plugin-json-pretty/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: ["./test-setup.ts"],
+  },
+});

--- a/packages/plugin-json-raw/package.json
+++ b/packages/plugin-json-raw/package.json
@@ -6,7 +6,9 @@
     ".": "./src/index.tsx"
   },
   "scripts": {
-    "lint": "eslint . --max-warnings 0"
+    "lint": "eslint . --max-warnings 0",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@repo/formatter-core": "*",
@@ -16,11 +18,15 @@
   "devDependencies": {
     "@repo/eslint-config": "*",
     "@repo/typescript-config": "*",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
     "@types/eslint": "^8.56.5",
     "@types/node": "^20.11.24",
     "@types/react": "^19.2.14",
     "eslint": "^8.57.0",
+    "jsdom": "^26.0.0",
     "react": "^19.2.5",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "vitest": "^4.1.5"
   }
 }

--- a/packages/plugin-json-raw/src/jsonRawFormatter.test.tsx
+++ b/packages/plugin-json-raw/src/jsonRawFormatter.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { jsonRawFormatter } from "./index";
+
+describe("jsonRawFormatter", () => {
+  it("has correct id and title", () => {
+    expect(jsonRawFormatter.id).toBe("json-raw-formatter");
+    expect(jsonRawFormatter.title).toBe("Original");
+  });
+
+  it("renders the raw content value", () => {
+    const element = jsonRawFormatter.format({
+      value: '{"key":"value"}',
+    });
+    const { container } = render(element as ReactElement);
+    expect(container).toHaveTextContent('{"key":"value"}');
+  });
+
+  it("renders plain text content", () => {
+    const element = jsonRawFormatter.format({ value: "plain text response" });
+    const { container } = render(element as ReactElement);
+    expect(container).toHaveTextContent("plain text response");
+  });
+
+  it("renders empty string for null value", () => {
+    const element = jsonRawFormatter.format({ value: null });
+    const { container } = render(element as ReactElement);
+    expect(container.firstChild).toBeTruthy();
+  });
+});

--- a/packages/plugin-json-raw/test-setup.ts
+++ b/packages/plugin-json-raw/test-setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom";

--- a/packages/plugin-json-raw/tsconfig.lint.json
+++ b/packages/plugin-json-raw/tsconfig.lint.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "outDir": "dist"
   },
-  "include": ["src"],
+  "include": ["src", "vitest.config.ts", "test-setup.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/plugin-json-raw/vitest.config.ts
+++ b/packages/plugin-json-raw/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: ["./test-setup.ts"],
+  },
+});

--- a/packages/plugin-user-agent-parse/package.json
+++ b/packages/plugin-user-agent-parse/package.json
@@ -6,7 +6,9 @@
     ".": "./src/index.tsx"
   },
   "scripts": {
-    "lint": "eslint . --max-warnings 0"
+    "lint": "eslint . --max-warnings 0",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@repo/formatter-core": "*",
@@ -17,12 +19,16 @@
   "devDependencies": {
     "@repo/eslint-config": "*",
     "@repo/typescript-config": "*",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
     "@types/eslint": "^8.56.5",
     "@types/node": "^20.11.24",
     "@types/react": "^19.2.14",
     "@types/ua-parser-js": "^0.7.39",
     "eslint": "^8.57.0",
+    "jsdom": "^26.0.0",
     "react": "^19.2.5",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "vitest": "^4.1.5"
   }
 }

--- a/packages/plugin-user-agent-parse/src/userAgentParseFormatter.test.tsx
+++ b/packages/plugin-user-agent-parse/src/userAgentParseFormatter.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { userAgentParseFormatter } from "./index";
+
+const chromeUserAgent =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
+const sampleHeader = { name: "User-Agent", value: chromeUserAgent };
+
+describe("userAgentParseFormatter", () => {
+  it("has correct id and title", () => {
+    expect(userAgentParseFormatter.id).toBe("user-agent-parse-formatter");
+    expect(userAgentParseFormatter.title).toBe("Parse");
+  });
+
+  it("renders browser badge for a known user agent", () => {
+    const element = userAgentParseFormatter.format(sampleHeader);
+    const { container } = render(element as ReactElement);
+    expect(container).toHaveTextContent("Browser");
+    expect(container).toHaveTextContent("Chrome");
+  });
+
+  it("renders OS badge for a known user agent", () => {
+    const element = userAgentParseFormatter.format(sampleHeader);
+    const { container } = render(element as ReactElement);
+    expect(container).toHaveTextContent("OS");
+    expect(container).toHaveTextContent("Windows");
+  });
+
+  it("renders without crashing for empty user agent value", () => {
+    const element = userAgentParseFormatter.format({
+      name: "User-Agent",
+      value: "",
+    });
+    const { container } = render(element as ReactElement);
+    expect(container.firstChild).toBeTruthy();
+  });
+});

--- a/packages/plugin-user-agent-parse/test-setup.ts
+++ b/packages/plugin-user-agent-parse/test-setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom";

--- a/packages/plugin-user-agent-parse/tsconfig.lint.json
+++ b/packages/plugin-user-agent-parse/tsconfig.lint.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "outDir": "dist"
   },
-  "include": ["src"],
+  "include": ["src", "vitest.config.ts", "test-setup.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/plugin-user-agent-parse/vitest.config.ts
+++ b/packages/plugin-user-agent-parse/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: ["./test-setup.ts"],
+  },
+});

--- a/packages/plugin-user-agent-raw/package.json
+++ b/packages/plugin-user-agent-raw/package.json
@@ -6,7 +6,9 @@
     ".": "./src/index.tsx"
   },
   "scripts": {
-    "lint": "eslint . --max-warnings 0"
+    "lint": "eslint . --max-warnings 0",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@repo/formatter-core": "*",
@@ -15,11 +17,15 @@
   "devDependencies": {
     "@repo/eslint-config": "*",
     "@repo/typescript-config": "*",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
     "@types/eslint": "^8.56.5",
     "@types/node": "^20.11.24",
     "@types/react": "^19.2.14",
     "eslint": "^8.57.0",
+    "jsdom": "^26.0.0",
     "react": "^19.2.5",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "vitest": "^4.1.5"
   }
 }

--- a/packages/plugin-user-agent-raw/src/userAgentRawFormatter.test.ts
+++ b/packages/plugin-user-agent-raw/src/userAgentRawFormatter.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { userAgentRawFormatter } from "./index";
+
+const chromeUserAgent =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
+describe("userAgentRawFormatter", () => {
+  it("has correct id and title", () => {
+    expect(userAgentRawFormatter.id).toBe("user-agent-raw-formatter");
+    expect(userAgentRawFormatter.title).toBe("Original");
+  });
+
+  it("returns the raw user agent string unchanged", () => {
+    const result = userAgentRawFormatter.format({
+      name: "User-Agent",
+      value: chromeUserAgent,
+    });
+    expect(result).toBe(chromeUserAgent);
+  });
+
+  it("returns empty string for null value", () => {
+    const result = userAgentRawFormatter.format({
+      name: "User-Agent",
+      value: null,
+    });
+    expect(result).toBe("");
+  });
+
+  it("returns the value verbatim for any string", () => {
+    const value = "custom/agent 1.0";
+    const result = userAgentRawFormatter.format({ name: "User-Agent", value });
+    expect(result).toBe(value);
+  });
+});

--- a/packages/plugin-user-agent-raw/test-setup.ts
+++ b/packages/plugin-user-agent-raw/test-setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom";

--- a/packages/plugin-user-agent-raw/tsconfig.lint.json
+++ b/packages/plugin-user-agent-raw/tsconfig.lint.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "outDir": "dist"
   },
-  "include": ["src"],
+  "include": ["src", "vitest.config.ts", "test-setup.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/plugin-user-agent-raw/vitest.config.ts
+++ b/packages/plugin-user-agent-raw/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: ["./test-setup.ts"],
+  },
+});


### PR DESCRIPTION
## Summary
- Added `vitest.config.ts` (jsdom environment) and `test-setup.ts` (@testing-library/jest-dom) to all 7 plugin packages
- Added `test` and `test:watch` scripts to each plugin `package.json`
- Added `vitest`, `@testing-library/react`, `@testing-library/jest-dom`, and `jsdom` as devDependencies in each plugin
- Updated `tsconfig.lint.json` in each plugin to include `vitest.config.ts` and `test-setup.ts`
- Wrote component test files covering formatter metadata and rendering with sample HAR data for all 7 plugins: `plugin-headers-plain`, `plugin-headers-raw`, `plugin-headers-table`, `plugin-json-pretty`, `plugin-json-raw`, `plugin-user-agent-parse`, `plugin-user-agent-raw`
- Also committed formatter-core test infrastructure (vitest.config.ts + 3 test files) that was left over from issue #23

Closes #29

Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>