### PR TITLE
feat(test): add Vitest hook tests for apps/web

### DIFF
--- a/apps/web/app/core/hooks/useDarkMode.test.ts
+++ b/apps/web/app/core/hooks/useDarkMode.test.ts
@@ -1,0 +1,31 @@
+// @vitest-environment jsdom
+import { renderHook } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { useDarkMode } from "./useDarkMode";
+
+function mockMatchMedia(matches: boolean) {
+  return vi.fn().mockImplementation((query: string) => ({
+    matches,
+    media: query,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  }));
+}
+
+describe("useDarkMode", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns true when dark mode is preferred", () => {
+    vi.stubGlobal("matchMedia", mockMatchMedia(true));
+    const { result } = renderHook(() => useDarkMode());
+    expect(result.current).toBe(true);
+  });
+
+  it("returns false when dark mode is not preferred", () => {
+    vi.stubGlobal("matchMedia", mockMatchMedia(false));
+    const { result } = renderHook(() => useDarkMode());
+    expect(result.current).toBe(false);
+  });
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -31,11 +31,15 @@
     "@next/eslint-plugin-next": "^16.2.4",
     "@repo/eslint-config": "*",
     "@repo/typescript-config": "*",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
     "@types/eslint": "^8.56.5",
     "@types/node": "^20.11.24",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^4.5.2",
     "eslint": "^8.57.0",
+    "jsdom": "^26.1.0",
     "typescript": "^5.3.3",
     "vitest": "^4.1.5"
   }

--- a/apps/web/src/test-setup.ts
+++ b/apps/web/src/test-setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom";

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,8 +1,11 @@
 import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
 
 export default defineConfig({
+  plugins: [react()],
   test: {
     environment: "node",
     globals: true,
+    setupFiles: ["./src/test-setup.ts"],
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -125,11 +125,15 @@
         "@next/eslint-plugin-next": "^16.2.4",
         "@repo/eslint-config": "*",
         "@repo/typescript-config": "*",
+        "@testing-library/jest-dom": "^6.6.3",
+        "@testing-library/react": "^16.3.0",
         "@types/eslint": "^8.56.5",
         "@types/node": "^20.11.24",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
+        "@vitejs/plugin-react": "^4.5.2",
         "eslint": "^8.57.0",
+        "jsdom": "^26.1.0",
         "typescript": "^5.3.3",
         "vitest": "^4.1.5"
       }


### PR DESCRIPTION
## Summary
- Add `useDarkMode.test.ts` with `// @vitest-environment jsdom` docblock and `matchMedia` mocked via `vi.stubGlobal`
- Add `src/test-setup.ts` with `@testing-library/jest-dom` import
- Update `vitest.config.ts` to include React plugin and `setupFiles`
- Add `@testing-library/react`, `@testing-library/jest-dom`, `@vitejs/plugin-react`, `jsdom` to devDependencies

Closes #30

Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>