### PR TITLE
feat(lint): integrate eslint-plugin-vitest into shared ESLint config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6277,6 +6277,31 @@
         "eslint": ">=8.44.0"
       }
     },
+    "node_modules/eslint-plugin-vitest": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vitest/-/eslint-plugin-vitest-0.5.4.tgz",
+      "integrity": "sha512-um+odCkccAHU53WdKAw39MY61+1x990uXjSPguUCq3VcEHdqJrOb8OTMrbYlY6f9jAKx7x98kLVlIe3RJeJqoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/utils": "^7.7.1"
+      },
+      "engines": {
+        "node": "^18.0.0 || >= 20.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "vitest": "*"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        },
+        "vitest": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -12604,6 +12629,7 @@
         "eslint-config-prettier": "^9.1.0",
         "eslint-config-turbo": "^2.9.6",
         "eslint-plugin-only-warn": "^1.1.0",
+        "eslint-plugin-vitest": "^0.5.4",
         "typescript": "^5.3.3"
       }
     },

--- a/packages/eslint-config/library.js
+++ b/packages/eslint-config/library.js
@@ -34,5 +34,10 @@ module.exports = {
     {
       files: ["*.js?(x)", "*.ts?(x)"],
     },
+    {
+      files: ["**/*.test.ts", "**/*.test.tsx"],
+      plugins: ["vitest"],
+      extends: ["plugin:vitest/legacy-recommended"],
+    },
   ],
 };

--- a/packages/eslint-config/next.js
+++ b/packages/eslint-config/next.js
@@ -31,5 +31,12 @@ module.exports = {
     "no-unused-vars": "off",
     "@typescript-eslint/no-unused-vars": "warn",
   },
-  overrides: [{ files: ["*.js?(x)", "*.ts?(x)"] }],
+  overrides: [
+    { files: ["*.js?(x)", "*.ts?(x)"] },
+    {
+      files: ["**/*.test.ts", "**/*.test.tsx"],
+      plugins: ["vitest"],
+      extends: ["plugin:vitest/legacy-recommended"],
+    },
+  ],
 };

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -12,6 +12,7 @@
     "eslint-config-turbo": "^2.9.6",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-only-warn": "^1.1.0",
+    "eslint-plugin-vitest": "^0.5.4",
     "@typescript-eslint/parser": "^7.1.0",
     "@typescript-eslint/eslint-plugin": "^7.1.0",
     "typescript": "^5.3.3"

--- a/packages/eslint-config/react-internal.js
+++ b/packages/eslint-config/react-internal.js
@@ -35,5 +35,10 @@ module.exports = {
   overrides: [
     // Force ESLint to detect .tsx files
     { files: ["*.js?(x)", "*.ts?(x)"] },
+    {
+      files: ["**/*.test.ts", "**/*.test.tsx"],
+      plugins: ["vitest"],
+      extends: ["plugin:vitest/legacy-recommended"],
+    },
   ],
 };


### PR DESCRIPTION
## Summary
- Add `eslint-plugin-vitest` as a devDependency in `packages/eslint-config`
- Add `plugin:vitest/legacy-recommended` override block targeting `**/*.test.ts` and `**/*.test.tsx` in all three config files (`library.js`, `next.js`, `react-internal.js`)
- Used `legacy-recommended` preset for ESLint 8 legacy config format compatibility

Closes #24

Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>