### PR TITLE
feat(formatter-core): add useFormatterSelection hook (#40)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12642,10 +12642,13 @@
       "devDependencies": {
         "@repo/eslint-config": "*",
         "@repo/typescript-config": "*",
+        "@testing-library/react": "^16.3.0",
         "@types/eslint": "^8.56.5",
         "@types/node": "^20.11.24",
         "@types/react": "^19.2.14",
+        "@vitejs/plugin-react": "^4.5.2",
         "eslint": "^8.57.0",
+        "jsdom": "^26.1.0",
         "react": "^19.2.5",
         "typescript": "^5.3.3",
         "vitest": "^4.1.5"
@@ -12672,12 +12675,18 @@
       "devDependencies": {
         "@repo/eslint-config": "*",
         "@repo/typescript-config": "*",
+        "@testing-library/jest-dom": "^6.6.3",
+        "@testing-library/react": "^16.3.0",
         "@types/eslint": "^8.56.5",
         "@types/node": "^20.11.24",
         "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.3",
+        "@vitejs/plugin-react": "^4.5.2",
         "eslint": "^8.57.0",
+        "jsdom": "^26.1.0",
         "react": "^19.2.5",
-        "typescript": "^5.3.3"
+        "typescript": "^5.3.3",
+        "vitest": "^4.1.5"
       }
     },
     "packages/formatter-ui/node_modules/@types/node": {

--- a/packages/formatter-core/package.json
+++ b/packages/formatter-core/package.json
@@ -14,10 +14,13 @@
   "devDependencies": {
     "@repo/eslint-config": "*",
     "@repo/typescript-config": "*",
+    "@testing-library/react": "^16.3.0",
     "@types/eslint": "^8.56.5",
     "@types/node": "^20.11.24",
     "@types/react": "^19.2.14",
+    "@vitejs/plugin-react": "^4.5.2",
     "eslint": "^8.57.0",
+    "jsdom": "^26.1.0",
     "react": "^19.2.5",
     "typescript": "^5.3.3",
     "vitest": "^4.1.5"

--- a/packages/formatter-core/src/index.ts
+++ b/packages/formatter-core/src/index.ts
@@ -8,3 +8,4 @@ export {
   type HostContext,
   type HostToast,
 } from "./HostContext";
+export { useFormatterSelection } from "./useFormatterSelection";

--- a/packages/formatter-core/src/useFormatterSelection.test.ts
+++ b/packages/formatter-core/src/useFormatterSelection.test.ts
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import type { Formatter } from "./Formatter";
+import { useFormatterSelection } from "./useFormatterSelection";
+
+function makeFormatter(id: string): Formatter<string> {
+  return {
+    id,
+    title: id,
+    icon: "",
+    tooltip: "",
+    format: vi.fn((data: string) => data),
+  };
+}
+
+describe("useFormatterSelection", () => {
+  it("returns empty activeId and null formatFn when formatterList is null", () => {
+    const { result } = renderHook(() => useFormatterSelection(null));
+    expect(result.current.activeId).toBe("");
+    expect(result.current.formatFn).toBeNull();
+  });
+
+  it("seeds activeId from the first key in formatterList", () => {
+    const fmt = makeFormatter("fmt-a");
+    const { result } = renderHook(() =>
+      useFormatterSelection({ "fmt-a": fmt }),
+    );
+    expect(result.current.activeId).toBe("fmt-a");
+    expect(result.current.formatFn).toBe(fmt.format);
+  });
+
+  it("switches formatFn when setActiveId is called", () => {
+    const fmtA = makeFormatter("fmt-a");
+    const fmtB = makeFormatter("fmt-b");
+    const list = { "fmt-a": fmtA, "fmt-b": fmtB };
+
+    const { result } = renderHook(() => useFormatterSelection(list));
+
+    expect(result.current.activeId).toBe("fmt-a");
+    expect(result.current.formatFn).toBe(fmtA.format);
+
+    act(() => result.current.setActiveId("fmt-b"));
+
+    expect(result.current.activeId).toBe("fmt-b");
+    expect(result.current.formatFn).toBe(fmtB.format);
+  });
+
+  it("returns null formatFn when activeId has no match in formatterList", () => {
+    const fmt = makeFormatter("fmt-a");
+    const { result } = renderHook(() =>
+      useFormatterSelection({ "fmt-a": fmt }),
+    );
+
+    act(() => result.current.setActiveId("nonexistent"));
+
+    expect(result.current.formatFn).toBeNull();
+  });
+});

--- a/packages/formatter-core/src/useFormatterSelection.ts
+++ b/packages/formatter-core/src/useFormatterSelection.ts
@@ -1,0 +1,15 @@
+import { useState } from "react";
+import type { Formatter } from "./Formatter";
+
+export function useFormatterSelection<T>(
+  formatterList: { [id: string]: Formatter<T> } | null,
+): {
+  activeId: string;
+  setActiveId: (id: string) => void;
+  formatFn: Formatter<T>["format"] | null;
+} {
+  const firstKey = formatterList ? (Object.keys(formatterList)[0] ?? "") : "";
+  const [activeId, setActiveId] = useState(firstKey);
+  const formatFn = formatterList?.[activeId]?.format ?? null;
+  return { activeId, setActiveId, formatFn };
+}

--- a/packages/formatter-core/vitest.config.ts
+++ b/packages/formatter-core/vitest.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
 
 export default defineConfig({
+  plugins: [react()],
   test: {
     environment: "node",
     globals: true,


### PR DESCRIPTION
## Summary

- Adds `useFormatterSelection<T>(formatterList)` hook to `@repo/formatter-core`
- Hook encapsulates the repeated formatter-switching protocol: registry lookup → first-key seeding → active-id state → `formatFn` derivation
- Exports the hook from `packages/formatter-core/src/index.ts`
- Adds `@testing-library/react`, `@vitejs/plugin-react`, and `jsdom` devDeps to support `renderHook`-based tests
- 4 tests covering: null list, first-key seeding, `setActiveId` switching, unmatched id → null `formatFn`

Closes #40
Blocks #41, #42

Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>