### PR TITLE
refactor: use useFormatterSelection in Headers, Content, HeadersValue (#41 #42)

### DIFF
--- a/apps/web/app/features/detail/components/Content.tsx
+++ b/apps/web/app/features/detail/components/Content.tsx
@@ -1,8 +1,8 @@
 import type React from "react";
-import { useState } from "react";
 import { findHeader } from "../../../core/helpers/findHeader";
 import { parseMimeType } from "../../../core/helpers/parseMimeType";
 import { contentValueFormatters } from "@repo/formatter-core/registry";
+import { useFormatterSelection } from "@repo/formatter-core";
 import { NoContent } from "@repo/ui/no-content";
 import { TextContent } from "@repo/ui/text-content";
 import { CollapsibleTitle } from "../../../components/CollapsibleTitle";
@@ -20,11 +20,7 @@ export function Content({ data }: { data: any }) {
     ? contentValueFormatters.getFormatters(mimeType)
     : null;
 
-  const firstKey = formatterList ? Object.keys(formatterList)[0] || "" : "";
-
-  const [actionId, setActionId] = useState(firstKey);
-
-  const formatFn = formatterList?.[actionId]?.format;
+  const { activeId, setActiveId, formatFn } = useFormatterSelection(formatterList);
   const size = content != null ? ` ${bodySize} B` : "No data";
   const info = [contentType.value, size].filter(Boolean).join(" | ");
   const title = <CollapsibleTitle title={"Content"} info={info} />;
@@ -44,8 +40,8 @@ export function Content({ data }: { data: any }) {
       title={title}
       disabled={!content}
       actions={formatterList}
-      activeActionId={actionId}
-      onAction={(actionId: string) => setActionId(actionId)}
+      activeActionId={activeId}
+      onAction={setActiveId}
     >
       {ContentValue}
     </Collapsible>

--- a/apps/web/app/features/detail/components/Headers.tsx
+++ b/apps/web/app/features/detail/components/Headers.tsx
@@ -1,6 +1,6 @@
 import type React from "react";
-import { useState } from "react";
 import { headersFormatters } from "@repo/formatter-core/registry";
+import { useFormatterSelection } from "@repo/formatter-core";
 import { Collapsible } from "../../../components/Collapsible";
 import { CollapsibleTitle } from "../../../components/CollapsibleTitle";
 import { NoContent } from "@repo/ui/no-content";
@@ -8,12 +8,9 @@ import { NoContent } from "@repo/ui/no-content";
 export function Headers({ data }: { data: any }) {
   const { headers, headersSize } = data;
 
-  const formatterList = headersFormatters.getFormatters("headers") || {};
-  const firstKey = Object.keys(formatterList)[0] || "";
+  const formatterList = headersFormatters.getFormatters("headers");
+  const { activeId, setActiveId, formatFn } = useFormatterSelection(formatterList);
 
-  const [actionId, setActionId] = useState(firstKey);
-
-  const formatFn = formatterList?.[actionId]?.format;
   const info = headers != null ? ` ${headersSize} B` : "No data";
   const title = <CollapsibleTitle title={"Headers"} info={info} />;
 
@@ -32,8 +29,8 @@ export function Headers({ data }: { data: any }) {
       title={title}
       disabled={!Array.isArray(headers) || headers.length === 0}
       actions={formatterList}
-      activeActionId={actionId}
-      onAction={(actionId: string) => setActionId(actionId)}
+      activeActionId={activeId}
+      onAction={setActiveId}
     >
       {HeadersContent}
     </Collapsible>

--- a/package-lock.json
+++ b/package-lock.json
@@ -12642,10 +12642,13 @@
       "devDependencies": {
         "@repo/eslint-config": "*",
         "@repo/typescript-config": "*",
+        "@testing-library/react": "^16.3.0",
         "@types/eslint": "^8.56.5",
         "@types/node": "^20.11.24",
         "@types/react": "^19.2.14",
+        "@vitejs/plugin-react": "^4.5.2",
         "eslint": "^8.57.0",
+        "jsdom": "^26.1.0",
         "react": "^19.2.5",
         "typescript": "^5.3.3",
         "vitest": "^4.1.5"
@@ -12672,12 +12675,18 @@
       "devDependencies": {
         "@repo/eslint-config": "*",
         "@repo/typescript-config": "*",
+        "@testing-library/jest-dom": "^6.6.3",
+        "@testing-library/react": "^16.3.0",
         "@types/eslint": "^8.56.5",
         "@types/node": "^20.11.24",
         "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.3",
+        "@vitejs/plugin-react": "^4.5.2",
         "eslint": "^8.57.0",
+        "jsdom": "^26.1.0",
         "react": "^19.2.5",
-        "typescript": "^5.3.3"
+        "typescript": "^5.3.3",
+        "vitest": "^4.1.5"
       }
     },
     "packages/formatter-ui/node_modules/@types/node": {

--- a/packages/formatter-core/package.json
+++ b/packages/formatter-core/package.json
@@ -14,10 +14,13 @@
   "devDependencies": {
     "@repo/eslint-config": "*",
     "@repo/typescript-config": "*",
+    "@testing-library/react": "^16.3.0",
     "@types/eslint": "^8.56.5",
     "@types/node": "^20.11.24",
     "@types/react": "^19.2.14",
+    "@vitejs/plugin-react": "^4.5.2",
     "eslint": "^8.57.0",
+    "jsdom": "^26.1.0",
     "react": "^19.2.5",
     "typescript": "^5.3.3",
     "vitest": "^4.1.5"

--- a/packages/formatter-core/src/index.ts
+++ b/packages/formatter-core/src/index.ts
@@ -8,3 +8,4 @@ export {
   type HostContext,
   type HostToast,
 } from "./HostContext";
+export { useFormatterSelection } from "./useFormatterSelection";

--- a/packages/formatter-core/src/useFormatterSelection.test.ts
+++ b/packages/formatter-core/src/useFormatterSelection.test.ts
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import type { Formatter } from "./Formatter";
+import { useFormatterSelection } from "./useFormatterSelection";
+
+function makeFormatter(id: string): Formatter<string> {
+  return {
+    id,
+    title: id,
+    icon: "",
+    tooltip: "",
+    format: vi.fn((data: string) => data),
+  };
+}
+
+describe("useFormatterSelection", () => {
+  it("returns empty activeId and null formatFn when formatterList is null", () => {
+    const { result } = renderHook(() => useFormatterSelection(null));
+    expect(result.current.activeId).toBe("");
+    expect(result.current.formatFn).toBeNull();
+  });
+
+  it("seeds activeId from the first key in formatterList", () => {
+    const fmt = makeFormatter("fmt-a");
+    const { result } = renderHook(() =>
+      useFormatterSelection({ "fmt-a": fmt }),
+    );
+    expect(result.current.activeId).toBe("fmt-a");
+    expect(result.current.formatFn).toBe(fmt.format);
+  });
+
+  it("switches formatFn when setActiveId is called", () => {
+    const fmtA = makeFormatter("fmt-a");
+    const fmtB = makeFormatter("fmt-b");
+    const list = { "fmt-a": fmtA, "fmt-b": fmtB };
+
+    const { result } = renderHook(() => useFormatterSelection(list));
+
+    expect(result.current.activeId).toBe("fmt-a");
+    expect(result.current.formatFn).toBe(fmtA.format);
+
+    act(() => result.current.setActiveId("fmt-b"));
+
+    expect(result.current.activeId).toBe("fmt-b");
+    expect(result.current.formatFn).toBe(fmtB.format);
+  });
+
+  it("returns null formatFn when activeId has no match in formatterList", () => {
+    const fmt = makeFormatter("fmt-a");
+    const { result } = renderHook(() =>
+      useFormatterSelection({ "fmt-a": fmt }),
+    );
+
+    act(() => result.current.setActiveId("nonexistent"));
+
+    expect(result.current.formatFn).toBeNull();
+  });
+});

--- a/packages/formatter-core/src/useFormatterSelection.ts
+++ b/packages/formatter-core/src/useFormatterSelection.ts
@@ -1,0 +1,15 @@
+import { useState } from "react";
+import type { Formatter } from "./Formatter";
+
+export function useFormatterSelection<T>(
+  formatterList: { [id: string]: Formatter<T> } | null,
+): {
+  activeId: string;
+  setActiveId: (id: string) => void;
+  formatFn: Formatter<T>["format"] | null;
+} {
+  const firstKey = formatterList ? (Object.keys(formatterList)[0] ?? "") : "";
+  const [activeId, setActiveId] = useState(firstKey);
+  const formatFn = formatterList?.[activeId]?.format ?? null;
+  return { activeId, setActiveId, formatFn };
+}

--- a/packages/formatter-core/vitest.config.ts
+++ b/packages/formatter-core/vitest.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
 
 export default defineConfig({
+  plugins: [react()],
   test: {
     environment: "node",
     globals: true,

--- a/packages/plugin-headers-table/src/HeadersValue.tsx
+++ b/packages/plugin-headers-table/src/HeadersValue.tsx
@@ -1,6 +1,6 @@
 import type React from "react";
-import { useState } from "react";
 import type { HeaderItem } from "@repo/formatter-core";
+import { useFormatterSelection } from "@repo/formatter-core";
 import { headerValueFormatters } from "@repo/formatter-core/registry";
 import { HeadersIcons } from "./HeadersIcons";
 
@@ -11,32 +11,17 @@ export function HeadersValue({
 }): React.JSX.Element | string {
   const { name, value } = headerItem;
 
-  const formatters = headerValueFormatters.getFormatters(name);
+  const formatterList = headerValueFormatters.getFormatters(name);
+  const { setActiveId, formatFn } = useFormatterSelection(formatterList);
 
-  if (!formatters) {
+  if (!formatterList || !formatFn) {
     return value || "";
   }
-
-  const firstId = Object.keys(formatters)[0];
-  if (!firstId) {
-    return value || "";
-  }
-
-  const [id, setId] = useState(firstId);
-
-  const formatter = formatters[id];
-  if (!formatter) {
-    return value || "";
-  }
-
-  const HeaderFormat = () => formatter.format(headerItem);
-
-  const setFormatter = (id: string) => setId(id);
 
   return (
     <>
-      <HeaderFormat />
-      <HeadersIcons formatters={formatters} setFormatter={setFormatter} />
+      {formatFn(headerItem)}
+      <HeadersIcons formatters={formatterList} setFormatter={setActiveId} />
     </>
   );
 }


### PR DESCRIPTION
## Summary

- `Headers.tsx`: replaced 4-line formatter-switching protocol with `useFormatterSelection(formatterList)`; removed `useState` import
- `Content.tsx`: same replacement; removed `useState` import
- `HeadersValue.tsx`: replaced manual protocol with `useFormatterSelection`; fixed pre-existing React Hooks violation (3 early `return` statements fired before `useState`)

This branch includes the `useFormatterSelection` hook from #43 (merges once that PR lands).

Closes #41
Closes #42
Depends on #43

Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>