### PR TITLE
chore: gitignore next-env.d.ts and untrack from both apps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
+# Next.js
+next-env.d.ts
+
 # Misc
 .DS_Store
 *.pem

--- a/apps/docs/next-env.d.ts
+++ b/apps/docs/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary

- Adds `next-env.d.ts` to root `.gitignore` — per [Next.js docs](https://nextjs.org/docs/app/api-reference/config/typescript), this file is auto-generated on every `next dev` / `next build` run and should not be tracked
- Removes `apps/docs/next-env.d.ts` and `apps/web/next-env.d.ts` from git tracking (`git rm --cached`)

Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>