### PR TITLE
feat(test): add Vitest setup and JsonView tests for formatter-ui

### DIFF
--- a/packages/eslint-config/library.js
+++ b/packages/eslint-config/library.js
@@ -25,6 +25,7 @@ module.exports = {
     ".*.js",
     "node_modules/",
     "dist/",
+    "coverage/",
   ],
   rules: {
     "no-unused-vars": "off",

--- a/packages/eslint-config/next.js
+++ b/packages/eslint-config/next.js
@@ -26,6 +26,7 @@ module.exports = {
     ".*.js",
     "node_modules/",
     "out/",
+    "coverage/",
   ],
   rules: {
     "no-unused-vars": "off",

--- a/packages/eslint-config/react-internal.js
+++ b/packages/eslint-config/react-internal.js
@@ -27,6 +27,7 @@ module.exports = {
     ".*.js",
     "node_modules/",
     "dist/",
+    "coverage/",
   ],
   rules: {
     "no-unused-vars": "off",

--- a/packages/formatter-ui/.eslintrc.js
+++ b/packages/formatter-ui/.eslintrc.js
@@ -7,4 +7,13 @@ module.exports = {
     project: "./tsconfig.lint.json",
     tsconfigRootDir: __dirname,
   },
+  overrides: [
+    {
+      files: ["**/*.test.ts", "**/*.test.tsx", "**/test-setup.ts"],
+      env: { es2020: true },
+      rules: {
+        "no-redeclare": "off",
+      },
+    },
+  ],
 };

--- a/packages/formatter-ui/package.json
+++ b/packages/formatter-ui/package.json
@@ -7,7 +7,9 @@
     "./json-view": "./src/json-view.tsx"
   },
   "scripts": {
-    "lint": "eslint . --max-warnings 0"
+    "lint": "eslint . --max-warnings 0",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@repo/formatter-core": "*",
@@ -17,11 +19,17 @@
   "devDependencies": {
     "@repo/eslint-config": "*",
     "@repo/typescript-config": "*",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
     "@types/eslint": "^8.56.5",
     "@types/node": "^20.11.24",
     "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^4.5.2",
     "eslint": "^8.57.0",
+    "jsdom": "^26.1.0",
     "react": "^19.2.5",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "vitest": "^4.1.5"
   }
 }

--- a/packages/formatter-ui/src/json-view.test.tsx
+++ b/packages/formatter-ui/src/json-view.test.tsx
@@ -1,0 +1,84 @@
+import React from "react";
+import { render, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { HostProvider } from "@repo/formatter-core";
+import { JsonView } from "./json-view";
+import type { HostContext } from "@repo/formatter-core";
+
+const defaultContext: HostContext = {
+  theme: "light",
+  jsonViewer: {
+    collapsed: 1,
+    indentWidth: 2,
+    enableClipboard: true,
+    displayDataTypes: false,
+    displayObjectSize: false,
+    highlightUpdates: false,
+    shortenTextAfterLength: 0,
+  },
+  notify: vi.fn(),
+};
+
+function renderWithHost(ui: React.ReactElement, ctx: HostContext = defaultContext) {
+  return render(<HostProvider value={ctx}>{ui}</HostProvider>);
+}
+
+describe("JsonView", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders without crashing", () => {
+    const { container } = renderWithHost(<JsonView data={{ key: "value" }} />);
+    expect(container.firstChild).toBeInTheDocument();
+  });
+
+  it("renders the outer wrapper div", () => {
+    const { container } = renderWithHost(<JsonView data={{ a: 1 }} />);
+    expect(container.querySelector(".group")).toBeInTheDocument();
+  });
+
+  it("renders collapse and expand buttons by default", () => {
+    const { container } = renderWithHost(<JsonView data={{ a: 1 }} />);
+    expect(container.querySelector(".material-symbols--expand-all-rounded")).toBeInTheDocument();
+    expect(container.querySelector(".material-symbols--collapse-all-rounded")).toBeInTheDocument();
+  });
+
+  it("does not render collapse/expand buttons when collapseBtns is false", () => {
+    const { container } = renderWithHost(<JsonView data={{ a: 1 }} collapseBtns={false} />);
+    expect(container.querySelector(".material-symbols--expand-all-rounded")).not.toBeInTheDocument();
+    expect(container.querySelector(".material-symbols--collapse-all-rounded")).not.toBeInTheDocument();
+  });
+
+  it("renders the clipboard button", () => {
+    const { container } = renderWithHost(<JsonView data={{ a: 1 }} />);
+    expect(container.querySelector(".material-symbols--content-copy-outline-rounded")).toBeInTheDocument();
+  });
+
+  it("calls clipboard API on copy button click", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      writable: true,
+      configurable: true,
+    });
+    const notify = vi.fn();
+    const ctx = { ...defaultContext, notify };
+
+    const { container } = renderWithHost(<JsonView data={{ foo: "bar" }} />, ctx);
+    const copyBtn = container.querySelector(".material-symbols--content-copy-outline-rounded") as HTMLElement;
+    fireEvent.click(copyBtn);
+
+    await vi.waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith('{\n  "foo": "bar"\n}');
+    });
+  });
+
+  it("throws when rendered outside HostProvider", () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(() => render(<JsonView data={{}} />)).toThrow(
+      "useFormatterHost must be used inside <HostProvider>",
+    );
+    consoleSpy.mockRestore();
+  });
+});

--- a/packages/formatter-ui/src/test-setup.ts
+++ b/packages/formatter-ui/src/test-setup.ts
@@ -1,0 +1,7 @@
+import "@testing-library/jest-dom";
+
+globalThis.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};

--- a/packages/formatter-ui/tsconfig.lint.json
+++ b/packages/formatter-ui/tsconfig.lint.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "outDir": "dist"
   },
-  "include": ["src"],
+  "include": ["src", "vitest.config.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/formatter-ui/vitest.config.ts
+++ b/packages/formatter-ui/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: ["./src/test-setup.ts"],
+  },
+});


### PR DESCRIPTION
## Summary

- Adds Vitest + jsdom + `@testing-library/react` setup to `@repo/formatter-ui`
- 7 tests for `JsonView`: rendering, collapse/expand buttons, clipboard copy, and `HostProvider` requirement enforcement
- Adds ESLint override for test files in `formatter-ui`
- Excludes `coverage/` from ESLint ignore lists in all three shared `@repo/eslint-config` configs

Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>