### PR TITLE
feat(list): add selectFilterFields selector, narrow List subscription

### DIFF
--- a/apps/web/app/features/list/components/List.tsx
+++ b/apps/web/app/features/list/components/List.tsx
@@ -3,7 +3,7 @@ import type React from "react";
 import { useEffect, useMemo } from "react";
 import { useAppStore } from "../../../store/store";
 import {
-  selectFilter,
+  selectFilterFields,
   selectPinnedIds,
   selectShowPinnedOnly,
   selectSorting,
@@ -56,7 +56,7 @@ function sortItemsArray(
 }
 
 export function List(): React.JSX.Element {
-  const filter = useAppStore(selectFilter);
+  const filterFields = useAppStore(selectFilterFields);
   const rawEntries = useAppStore(selectRawEntries);
   const { hideEmptyPages } = useAppStore(selectSettings);
   const sorting = useAppStore(selectSorting);
@@ -71,7 +71,7 @@ export function List(): React.JSX.Element {
       ? rawListData.filter((entry: any) => pinnedIds.has(entry.$$id))
       : rawListData;
 
-  const entriesWithVisibility = rawListPinned.map(markVisible(filter));
+  const entriesWithVisibility = rawListPinned.map(markVisible(filterFields));
   const visibleEntries = entriesWithVisibility.filter(
     (entry: any) => !entry.$$hidden,
   );

--- a/apps/web/app/features/list/helpers/filter.test.ts
+++ b/apps/web/app/features/list/helpers/filter.test.ts
@@ -2,10 +2,10 @@ import { describe, it, expect } from "vitest";
 import { markVisible } from "./filter";
 
 const makeFilter = (fields = {}) => ({
-  visible: true,
-  active: true,
-  count: 0,
-  fields: { url: "", method: "", status: "", ...fields },
+  url: "",
+  method: "",
+  status: "",
+  ...fields,
 });
 
 const makeItem = (overrides = {}) => ({

--- a/apps/web/app/features/list/helpers/filter.ts
+++ b/apps/web/app/features/list/helpers/filter.ts
@@ -60,7 +60,7 @@ const resolveVectors =
  * @param filter
  * @returns map method
  */
-export const markVisible = ({ fields }: Filter) => {
+export const markVisible = (fields: Filter["fields"]) => {
   const tokenVectors = getTokenVectors(fields);
 
   return (listItem: any): any => {
@@ -84,7 +84,7 @@ export const markVisible = ({ fields }: Filter) => {
  * @param filter
  * @returns reduce method
  */
-export const reduceData = ({ fields }: Filter) => {
+export const reduceData = (fields: Filter["fields"]) => {
   const tokenVectors = getTokenVectors(fields);
 
   return (acc: any, listItem: any, index: number, arr: any[]): any => {

--- a/apps/web/app/features/list/selectors.ts
+++ b/apps/web/app/features/list/selectors.ts
@@ -1,6 +1,7 @@
 import { AppState } from "../../store/store";
 
 export const selectFilter = (state: AppState) => state.filter;
+export const selectFilterFields = (state: AppState) => state.filter.fields;
 export const selectSorting = (state: AppState) => state.sorting;
 export const selectPinnedIds = (state: AppState) => state.ui.pinnedIds;
 export const selectRowId = (state: AppState) => state.ui.rowId;


### PR DESCRIPTION
## Summary

- Added `selectFilterFields` selector in `selectors.ts` that returns only `state.filter.fields` (instead of the full `state.filter` object)
- Replaced `useAppStore(selectFilter)` with `useAppStore(selectFilterFields)` in `List.tsx` to break the re-render loop caused by `setFilteredCount` mutating `filter.count` on the same `filter` object that `List` was subscribed to
- Updated `markVisible` signature in `filter.ts` to accept `Filter["fields"]` directly (it only used `fields` internally anyway), removing the destructuring wrapper
- Updated `reduceData` signature in `filter.ts` consistently for the same reason
- Updated `filter.test.ts` to pass `Filter["fields"]` shape directly to `markVisible` (matching the new signature)

## Test plan

- [ ] Build passes: `npm run build`
- [ ] No re-render loop when `setFilteredCount` fires in the `useEffect` in `List.tsx`
- [ ] Filter functionality in the list still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)