### PR TITLE
fix(core): remove selectFileEntries array recreation on every selector call (#50)

### DIFF
--- a/apps/web/app/core/selectors.test.ts
+++ b/apps/web/app/core/selectors.test.ts
@@ -16,7 +16,6 @@ import {
   selectHarData,
   selectRawEntries,
   selectRawEntry,
-  selectFileEntries,
   selectEntry,
   selectFileSize,
   selectEntriesNum,
@@ -107,23 +106,6 @@ describe("selectRawEntry", () => {
       ui: { ...initialUiState, fileId: "f1", rowId: 1 },
     });
     expect(selectRawEntry(state)).toEqual({ request: { url: "b" } });
-  });
-});
-
-describe("selectFileEntries", () => {
-  it("returns empty array when no file selected", () => {
-    expect(selectFileEntries(makeState())).toEqual([]);
-  });
-
-  it("maps entries with $$id index", () => {
-    const entries = [{ request: { url: "a" } }, { request: { url: "b" } }];
-    const state = makeState({
-      files: [makeFile({ fileId: "f1", data: { log: { entries } } })],
-      ui: { ...initialUiState, fileId: "f1" },
-    });
-    const result = selectFileEntries(state);
-    expect(result[0]).toMatchObject({ request: { url: "a" }, $$id: 0 });
-    expect(result[1]).toMatchObject({ request: { url: "b" }, $$id: 1 });
   });
 });
 

--- a/apps/web/app/core/selectors.ts
+++ b/apps/web/app/core/selectors.ts
@@ -26,25 +26,16 @@ export const selectRawEntry = (state: AppState) => {
   return entries[rowId] ?? null;
 };
 
-export const selectFileEntries = (state: AppState) => {
-  const file = selectFile(state);
-  const entries = file?.data?.log?.entries;
-
-  if (!Array.isArray(entries)) {
-    return [];
-  }
-
-  return entries.map((entry: any, index: number) => ({
-    ...entry,
-    $$id: index,
-  }));
-};
-
 export function selectEntry(state: AppState) {
-  const entries = selectFileEntries(state);
+  const entries = selectFile(state)?.data?.log?.entries;
   const rowId = selectRowId(state);
 
-  return entries.find((entry: any) => entry.$$id === rowId);
+  if (!Array.isArray(entries) || rowId == null) return undefined;
+
+  const entry = entries[rowId];
+  if (entry == null) return undefined;
+
+  return { ...entry, $$id: rowId };
 }
 
 export const selectFileSize = (state: AppState) => {


### PR DESCRIPTION
## Summary

- Audited all usages of `selectFileEntries` — only `selectEntry` consumed it
- Removed `selectFileEntries` and inlined the direct index lookup (`entries[rowId]`) inside `selectEntry`, eliminating the `.map()` call that returned a new array reference on every invocation
- Updated `selectors.test.ts` to remove the `selectFileEntries` import and its describe block

## Test plan

- [ ] `selectEntry` still returns the correct entry with `$$id` attached for the current `rowId`
- [ ] `selectEntry` returns `undefined` when no file is selected or `rowId` is null
- [ ] Lint passes (`npm run lint`)
- [ ] Build passes (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)