### PR TITLE
feat(list): wrap ListItemWrapper in React.memo

### DIFF
--- a/apps/web/app/features/list/components/ListItemWrapper.tsx
+++ b/apps/web/app/features/list/components/ListItemWrapper.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-export default function ListItemWrapper({
+function ListItemWrapper({
   selected = false,
   pinned = false,
   error = false,
@@ -36,3 +36,5 @@ export default function ListItemWrapper({
     </div>
   );
 }
+
+export default React.memo(ListItemWrapper);


### PR DESCRIPTION
## Summary
- Wrap ListItemWrapper default export in React.memo
- Wrapper no longer re-renders when parent re-renders with identical props
- Closes #52

Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>