### PR TITLE
feat(har-types): add type guards and vitest unit tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12030,7 +12030,8 @@
         "@types/har-format": "^1.2.16",
         "@types/node": "^20.11.24",
         "eslint": "^8.57.0",
-        "typescript": "^5.3.3"
+        "typescript": "^5.3.3",
+        "vitest": "^4.1.5"
       }
     },
     "packages/har-types/node_modules/@types/node": {

--- a/packages/har-types/package.json
+++ b/packages/har-types/package.json
@@ -6,7 +6,9 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "lint": "eslint . --max-warnings 0"
+    "lint": "eslint . --max-warnings 0",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "devDependencies": {
     "@repo/eslint-config": "*",
@@ -14,6 +16,7 @@
     "@types/har-format": "^1.2.16",
     "@types/node": "^20.11.24",
     "eslint": "^8.57.0",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "vitest": "^4.1.5"
   }
 }

--- a/packages/har-types/src/guards.test.ts
+++ b/packages/har-types/src/guards.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { isHar, hasPostDataText, hasPostDataParams } from './guards';
+import type { PostData } from './types';
+
+const validHar = {
+  log: {
+    version: '1.2',
+    creator: { name: 'Browser', version: '1.0' },
+    entries: [],
+  },
+};
+
+describe('isHar', () => {
+  it('returns true for a valid HAR object', () => {
+    expect(isHar(validHar)).toBe(true);
+  });
+
+  it('returns false for null', () => {
+    expect(isHar(null)).toBe(false);
+  });
+
+  it('returns false for a string', () => {
+    expect(isHar('har')).toBe(false);
+  });
+
+  it('returns false for an array', () => {
+    expect(isHar([])).toBe(false);
+  });
+
+  it('returns false for a plain object without log', () => {
+    expect(isHar({})).toBe(false);
+  });
+
+  it('returns false when log.entries is missing', () => {
+    expect(isHar({ log: { creator: { name: 'x', version: '1' } } })).toBe(false);
+  });
+
+  it('returns false when log.entries is not an array', () => {
+    expect(isHar({ log: { creator: { name: 'x', version: '1' }, entries: null } })).toBe(false);
+  });
+
+  it('returns false when log.creator is missing', () => {
+    expect(isHar({ log: { entries: [] } })).toBe(false);
+  });
+
+  it('returns false when creator.name is not a string', () => {
+    expect(isHar({ log: { entries: [], creator: { name: 1, version: '1' } } })).toBe(false);
+  });
+
+  it('returns false when creator.version is not a string', () => {
+    expect(isHar({ log: { entries: [], creator: { name: 'x', version: 2 } } })).toBe(false);
+  });
+});
+
+describe('hasPostDataText', () => {
+  it('returns true when text is a non-empty string', () => {
+    const pd: PostData = { mimeType: 'text/plain', text: 'body content' };
+    expect(hasPostDataText(pd)).toBe(true);
+  });
+
+  it('returns false when text is undefined', () => {
+    const pd: PostData = { mimeType: 'text/plain' };
+    expect(hasPostDataText(pd)).toBe(false);
+  });
+
+  it('returns false when text is an empty string', () => {
+    const pd: PostData = { mimeType: 'text/plain', text: '' };
+    expect(hasPostDataText(pd)).toBe(false);
+  });
+});
+
+describe('hasPostDataParams', () => {
+  it('returns true when params is a non-empty array', () => {
+    const pd: PostData = { mimeType: 'application/x-www-form-urlencoded', params: [{ name: 'key', value: 'val' }] };
+    expect(hasPostDataParams(pd)).toBe(true);
+  });
+
+  it('returns false when params is undefined', () => {
+    const pd: PostData = { mimeType: 'application/x-www-form-urlencoded' };
+    expect(hasPostDataParams(pd)).toBe(false);
+  });
+
+  it('returns false when params is an empty array', () => {
+    const pd: PostData = { mimeType: 'application/x-www-form-urlencoded', params: [] };
+    expect(hasPostDataParams(pd)).toBe(false);
+  });
+});

--- a/packages/har-types/src/guards.ts
+++ b/packages/har-types/src/guards.ts
@@ -1,0 +1,39 @@
+import type { Har, PostData, Param } from "./types";
+
+export function isHar(data: unknown): data is Har {
+  if (data === null || typeof data !== "object") {
+    return false;
+  }
+
+  const obj = data as Record<string, unknown>;
+  if (obj["log"] === null || typeof obj["log"] !== "object") {
+    return false;
+  }
+
+  const log = obj["log"] as Record<string, unknown>;
+  if (!Array.isArray(log["entries"])) {
+    return false;
+  }
+
+  if (log["creator"] === null || typeof log["creator"] !== "object") {
+    return false;
+  }
+
+  const creator = log["creator"] as Record<string, unknown>;
+  return (
+    typeof creator["name"] === "string" &&
+    typeof creator["version"] === "string"
+  );
+}
+
+export function hasPostDataText(
+  pd: PostData,
+): pd is PostData & { text: string } {
+  return typeof pd.text === "string" && pd.text.length > 0;
+}
+
+export function hasPostDataParams(
+  pd: PostData,
+): pd is PostData & { params: Param[] } {
+  return Array.isArray(pd.params) && pd.params.length > 0;
+}

--- a/packages/har-types/src/index.ts
+++ b/packages/har-types/src/index.ts
@@ -20,3 +20,5 @@ export type {
   CacheDetails,
   Timings,
 } from './types';
+
+export { isHar, hasPostDataText, hasPostDataParams } from './guards';

--- a/packages/har-types/tsconfig.lint.json
+++ b/packages/har-types/tsconfig.lint.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "outDir": "dist"
   },
-  "include": ["src"],
+  "include": ["src", "vitest.config.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/har-types/vitest.config.ts
+++ b/packages/har-types/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+  },
+});


### PR DESCRIPTION
## Summary
- Add `src/guards.ts` with `isHar`, `hasPostDataText`, and `hasPostDataParams` type guard functions
- Export all three guards from `src/index.ts`
- Add `src/guards.test.ts` with 16 vitest unit tests covering valid and invalid inputs
- Add vitest dependency and `test`/`test:watch` scripts to `package.json`
- Add `vitest.config.ts` and update `tsconfig.lint.json` to include test files

Closes #62

Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>