### PR TITLE
feat(web): wire @repo/har-types into apps/web

### DIFF
--- a/apps/web/app/core/selectors.test.ts
+++ b/apps/web/app/core/selectors.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 
 vi.mock("../plugins.config", () => ({}));
 
+import type { Har } from "@repo/har-types";
 import type { AppState } from "../store/store";
 import {
   initialUiState,
@@ -33,7 +34,7 @@ const makeState = (overrides: Partial<AppState> = {}): AppState => ({
   ...overrides,
 });
 
-const makeFile = (overrides: Partial<{ fileId: string; name: string; size: number; data: any }> = {}) => ({
+const makeFile = (overrides: Partial<{ fileId: string; name: string; size: number; data: Har | null }> = {}) => ({
   fileId: "file-1",
   name: "test.har",
   size: 1024,
@@ -72,7 +73,7 @@ describe("selectHarData", () => {
   it("returns log from selected file", () => {
     const log = { entries: [], pages: [] };
     const state = makeState({
-      files: [makeFile({ fileId: "f1", data: { log } })],
+      files: [makeFile({ fileId: "f1", data: { log } as unknown as Har })],
       ui: { ...initialUiState, fileId: "f1" },
     });
     expect(selectHarData(state)).toBe(log);
@@ -87,7 +88,7 @@ describe("selectRawEntries", () => {
   it("returns entries array from selected file", () => {
     const entries = [{ request: {} }, { request: {} }];
     const state = makeState({
-      files: [makeFile({ fileId: "f1", data: { log: { entries } } })],
+      files: [makeFile({ fileId: "f1", data: { log: { entries } } as unknown as Har })],
       ui: { ...initialUiState, fileId: "f1" },
     });
     expect(selectRawEntries(state)).toBe(entries);
@@ -102,7 +103,7 @@ describe("selectRawEntry", () => {
   it("returns entry at rowId index", () => {
     const entries = [{ request: { url: "a" } }, { request: { url: "b" } }];
     const state = makeState({
-      files: [makeFile({ fileId: "f1", data: { log: { entries } } })],
+      files: [makeFile({ fileId: "f1", data: { log: { entries } } as unknown as Har })],
       ui: { ...initialUiState, fileId: "f1", rowId: 1 },
     });
     expect(selectRawEntry(state)).toEqual({ request: { url: "b" } });
@@ -117,7 +118,7 @@ describe("selectEntry", () => {
   it("returns entry matching rowId", () => {
     const entries = [{ request: { url: "a" } }, { request: { url: "b" } }];
     const state = makeState({
-      files: [makeFile({ fileId: "f1", data: { log: { entries } } })],
+      files: [makeFile({ fileId: "f1", data: { log: { entries } } as unknown as Har })],
       ui: { ...initialUiState, fileId: "f1", rowId: 0 },
     });
     expect(selectEntry(state)).toMatchObject({ request: { url: "a" }, $$id: 0 });
@@ -146,7 +147,7 @@ describe("selectEntriesNum", () => {
   it("returns entry count", () => {
     const entries = [{}, {}, {}];
     const state = makeState({
-      files: [makeFile({ fileId: "f1", data: { log: { entries } } })],
+      files: [makeFile({ fileId: "f1", data: { log: { entries } } as unknown as Har })],
       ui: { ...initialUiState, fileId: "f1" },
     });
     expect(selectEntriesNum(state)).toBe(3);

--- a/apps/web/app/core/selectors.ts
+++ b/apps/web/app/core/selectors.ts
@@ -1,3 +1,4 @@
+import type { Log, Entry } from "@repo/har-types";
 import { AppState } from "../store/store";
 import { selectFiles, selectFileId } from "../features/file/selectors";
 import { selectRowId } from "../features/list/selectors";
@@ -13,20 +14,20 @@ export const selectFile = (state: AppState) => {
   return files.find((file) => file.fileId === fileId) || null;
 };
 
-export const selectHarData = (state: AppState) =>
-  selectFile(state)?.data?.log || null;
+export const selectHarData = (state: AppState): Log | null =>
+  selectFile(state)?.data?.log ?? null;
 
-export const selectRawEntries = (state: AppState) =>
+export const selectRawEntries = (state: AppState): Entry[] | null =>
   selectFile(state)?.data?.log?.entries ?? null;
 
-export const selectRawEntry = (state: AppState) => {
+export const selectRawEntry = (state: AppState): Entry | null => {
   const entries = selectFile(state)?.data?.log?.entries;
   const rowId = selectRowId(state);
   if (!Array.isArray(entries) || rowId == null) return null;
   return entries[rowId] ?? null;
 };
 
-export function selectEntry(state: AppState) {
+export function selectEntry(state: AppState): (Entry & { $$id: number }) | undefined {
   const entries = selectFile(state)?.data?.log?.entries;
   const rowId = selectRowId(state);
 

--- a/apps/web/app/features/file/helpers/openFile.ts
+++ b/apps/web/app/features/file/helpers/openFile.ts
@@ -1,5 +1,6 @@
 import type React from "react";
 import { nanoid } from "nanoid";
+import { isHar } from "@repo/har-types";
 import { readFileData } from "./readFileData";
 import { addFile, setFileId } from "../actions";
 import { setRowId } from "../../list/actions";
@@ -11,7 +12,13 @@ export async function openFile(file: File, message: string | React.JSX.Element) 
 
   try {
     const rawData = await readFileData(file);
-    const data = JSON.parse(rawData);
+    const data: unknown = JSON.parse(rawData);
+
+    if (!isHar(data)) {
+      addToast({ type: "alert", message });
+      return;
+    }
+
     addFile({ fileId, name, size, data });
     setFileId(fileId);
     setRowId(0);

--- a/apps/web/app/features/list/helpers/deriveListData.ts
+++ b/apps/web/app/features/list/helpers/deriveListData.ts
@@ -1,4 +1,6 @@
-export function deriveListData(entries: any[]): any[] {
+import type { Entry } from "@repo/har-types";
+
+export function deriveListData(entries: Entry[] | null): any[] {
   if (!Array.isArray(entries)) return [];
 
   return entries.map((entry: any, index: number) => {

--- a/apps/web/app/store/store.ts
+++ b/apps/web/app/store/store.ts
@@ -1,4 +1,5 @@
 import type React from "react";
+import type { Har } from "@repo/har-types";
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 import type { JsonViewerSettings } from "@repo/formatter-core";
@@ -11,7 +12,7 @@ export type File = {
   fileId: string;
   name: string;
   size: number;
-  data: any;
+  data: Har | null;
 };
 
 export type Filter = {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@repo/har-types": "*",
     "@repo/formatter-core": "*",
     "@repo/formatter-ui": "*",
     "@repo/plugin-headers-plain": "*",


### PR DESCRIPTION
## Summary
- Add `@repo/har-types` as a dependency of `apps/web`
- Replace `File.data: any` with `Har | null` in the store type
- Guard `openFile` with `isHar()` — shows error toast for invalid HAR files instead of crashing
- Annotate `selectHarData`, `selectRawEntries`, `selectRawEntry`, and `selectEntry` with explicit `Log` / `Entry` return types
- Update `deriveListData` to accept `Entry[] | null` so callers no longer need to pass `any[]`

Closes #63

Generated with [Claude Code](https://claude.ai/claude-code)
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>