### PR TITLE
refactor(web): list feature type safety — ListItem, SortField, typed transformations

### DIFF
--- a/apps/web/app/features/list/actions.ts
+++ b/apps/web/app/features/list/actions.ts
@@ -1,6 +1,7 @@
 import {
   useAppStore,
   Filter,
+  SortField,
   initialFilterState,
   initialFilterFieldsState,
 } from "../../store/store";
@@ -43,7 +44,7 @@ export const setFilterFields = (newFilterFields: Filter["fields"]) =>
   }));
 
 export const setSorting = (
-  sortBy?: "url" | "status" | "method" | "time" | "pageref",
+  sortBy?: SortField,
   dir?: "asc" | "desc",
 ) =>
   useAppStore.setState((state) => {

--- a/apps/web/app/features/list/components/HiddenItemsGroup.tsx
+++ b/apps/web/app/features/list/components/HiddenItemsGroup.tsx
@@ -4,8 +4,9 @@ import { Collapsible } from "../../../components/Collapsible";
 import { HiddenCount } from "./HiddenCount";
 import { ListItem } from "./ListItem";
 import { PanelList } from "./PanelList";
+import type { ListItem as ListItemType } from "../types";
 
-export function HiddenItemsGroup({ group }: { group: any[] }) {
+export function HiddenItemsGroup({ group }: { group: ListItemType[] }) {
   const rowId = useAppStore(selectRowId);
   const pinnedIds = useAppStore(selectPinnedIds);
 

--- a/apps/web/app/features/list/components/List.tsx
+++ b/apps/web/app/features/list/components/List.tsx
@@ -17,17 +17,18 @@ import { groupByProperty } from "../helpers/groupByProperty";
 import { PanelList } from "./PanelList";
 import { ListItems } from "./ListItems";
 import { PageRefGroup } from "./PageRefGroup";
+import type { ListItem, SortField } from "../types";
 
 function sortItemsArray(
-  items: any[],
-  sortBy?: string | undefined,
+  items: ListItem[],
+  sortBy?: SortField | undefined,
   sortDirection: "asc" | "desc" = "asc",
 ) {
   if (!sortBy) return items.slice();
 
   const directionFactor = sortDirection === "asc" ? 1 : -1;
 
-  const compareValues = (a: any, b: any) => {
+  const compareValues = (a: ListItem, b: ListItem) => {
     const va = a[sortBy];
     const vb = b[sortBy];
 
@@ -69,7 +70,7 @@ export function List(): React.JSX.Element {
   const rawListPinned = useMemo(
     () =>
       showPinnedOnly && pinnedIds.size > 0
-        ? rawListData.filter((entry: any) => pinnedIds.has(entry.$$id))
+        ? rawListData.filter((entry) => pinnedIds.has(entry.$$id))
         : rawListData,
     [rawListData, showPinnedOnly, pinnedIds],
   );
@@ -80,7 +81,7 @@ export function List(): React.JSX.Element {
   );
 
   const visibleEntries = useMemo(
-    () => entriesWithVisibility.filter((entry: any) => !entry.$$hidden),
+    () => entriesWithVisibility.filter((entry) => !entry.$$hidden),
     [entriesWithVisibility],
   );
 

--- a/apps/web/app/features/list/components/ListItem.tsx
+++ b/apps/web/app/features/list/components/ListItem.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { setRowId, togglePinnedRow } from "../actions";
+import type { ListItem as ListItemType } from "../types";
 import { Method } from "@repo/ui/method";
 import { Url } from "@repo/ui/url";
 import { Status } from "@repo/ui/status";
@@ -16,7 +17,7 @@ function ListItemComponent({
   isSelected,
   isPinned,
 }: {
-  item: any;
+  item: ListItemType;
   isSelected: boolean;
   isPinned: boolean;
 }): React.JSX.Element {
@@ -32,7 +33,7 @@ function ListItemComponent({
     $$hidden,
   } = item;
 
-  const isError = parseInt(status) <= 599 && parseInt(status) >= 400;
+  const isError = status <= 599 && status >= 400;
 
   const highlightNum = false;
   const numClasses = highlightNum

--- a/apps/web/app/features/list/components/ListItems.tsx
+++ b/apps/web/app/features/list/components/ListItems.tsx
@@ -4,15 +4,18 @@ import { useAppStore } from "../../../store/store";
 import { selectPinnedIds, selectRowId } from "../selectors";
 import { HiddenItemsGroup } from "./HiddenItemsGroup";
 import { ListItem } from "./ListItem";
+import type { ListItem as ListItemType } from "../types";
 
-export function ListItems({ items }: { items: any[] }) {
+export function ListItems({ items }: { items: ListItemType[] }) {
   const { groupHidden, excludeHidden } = useAppStore(selectSettings);
   const rowId = useAppStore(selectRowId);
   const pinnedIds = useAppStore(selectPinnedIds);
 
   return groupByProperty(items, "$$hidden").map((group) => {
-    if (groupHidden && !excludeHidden && group[0].$$hidden) {
-      return <HiddenItemsGroup key={"hidden-" + group[0].$$id} group={group} />;
+    const [firstItem] = group;
+    if (!firstItem) return null;
+    if (groupHidden && !excludeHidden && firstItem.$$hidden) {
+      return <HiddenItemsGroup key={"hidden-" + firstItem.$$id} group={group} />;
     }
 
     return group.map((item) => {

--- a/apps/web/app/features/list/components/PageRef.tsx
+++ b/apps/web/app/features/list/components/PageRef.tsx
@@ -7,12 +7,12 @@ export function PageRef({
   pageref,
   counts,
 }: {
-  pageref: any;
+  pageref: string | undefined;
   counts?: number;
 }) {
   const harData = useAppStore(selectHarData);
   const pages = harData?.pages || [];
-  const title = pages.find((page: any) => page.id === pageref)?.title || null;
+  const title = pages.find((page) => page.id === pageref)?.title || null;
 
   return (
     <div>

--- a/apps/web/app/features/list/components/PageRefGroup.tsx
+++ b/apps/web/app/features/list/components/PageRefGroup.tsx
@@ -2,9 +2,10 @@ import { Collapsible } from "../../../components/Collapsible";
 import { ListItems } from "./ListItems";
 import { PageRef } from "./PageRef";
 import { PanelList } from "./PanelList";
+import type { ListItem } from "../types";
 
-export function PageRefGroup({ items }: { items: any[] }) {
-  const title = <PageRef pageref={items[0].pageref} />;
+export function PageRefGroup({ items }: { items: ListItem[] }) {
+  const title = <PageRef pageref={items[0]?.pageref} />;
 
   return (
     <Collapsible title={title} disabled={items.length === 0}>

--- a/apps/web/app/features/list/helpers/deriveListData.ts
+++ b/apps/web/app/features/list/helpers/deriveListData.ts
@@ -1,12 +1,13 @@
 import type { Entry } from "@repo/har-types";
+import type { ListItem } from "../types";
 
-export function deriveListData(entries: Entry[] | null): any[] {
+export function deriveListData(entries: Entry[] | null): ListItem[] {
   if (!Array.isArray(entries)) return [];
 
-  return entries.map((entry: any, index: number) => {
+  return entries.map((entry, index) => {
     const { pageref, startedDateTime, time, request, response } = entry;
     const { method, url } = request;
     const { status, statusText } = response;
-    return { $$id: index, pageref, status, statusText, url, method, startedDateTime, time };
+    return { $$id: index, $$visible: false, $$hidden: false, pageref, status, statusText, url, method, startedDateTime, time };
   });
 }

--- a/apps/web/app/features/list/helpers/filter.ts
+++ b/apps/web/app/features/list/helpers/filter.ts
@@ -1,4 +1,5 @@
 import { Filter } from "../../../store/store";
+import type { ListItem } from "../types";
 
 /**
  * Returns list of field name and token pairs
@@ -40,18 +41,19 @@ const pairTokenWithField = (fieldName: string) => (token: string) => [
   token,
 ];
 
-const resolveToken = (str: string, token: string) =>
-  str.toString().toLowerCase().includes(token.toLocaleLowerCase());
+const resolveToken = (str: string | number | boolean | undefined, token: string) =>
+  String(str ?? "").toLowerCase().includes(token.toLocaleLowerCase());
 
 const resolveVectors =
-  (listItem: any) => (acc: boolean, tokenVector: [string, string]) => {
+  (listItem: ListItem) => (acc: boolean, tokenVector: [string, string]) => {
     const [fieldName, token] = tokenVector;
+    const value = listItem[fieldName as keyof ListItem];
 
     if (token.startsWith("-") && token.length > 1) {
-      return acc && !resolveToken(listItem[fieldName], token.substring(1));
+      return acc && !resolveToken(value, token.substring(1));
     }
 
-    return acc && resolveToken(listItem[fieldName], token);
+    return acc && resolveToken(value, token);
   };
 
 /**
@@ -63,7 +65,7 @@ const resolveVectors =
 export const markVisible = (fields: Filter["fields"]) => {
   const tokenVectors = getTokenVectors(fields);
 
-  return (listItem: any): any => {
+  return (listItem: ListItem): ListItem => {
     const shouldBeVisible =
       tokenVectors.length < 1 ||
       tokenVectors.reduce(resolveVectors(listItem), true);

--- a/apps/web/app/features/list/helpers/groupByProperty.ts
+++ b/apps/web/app/features/list/helpers/groupByProperty.ts
@@ -1,9 +1,11 @@
-export function groupByProperty(items: any[], prop: string): any[][] {
-  return items.reduce((acc: any[], item: any, index: number, arr: any[]) => {
-    if (index === 0 || item[prop] !== arr[index - 1][prop]) {
+export function groupByProperty<T>(items: T[], prop: keyof T): T[][] {
+  return items.reduce((acc: T[][], item: T, index: number, arr: T[]) => {
+    const prev = arr[index - 1];
+    const lastGroup = acc[acc.length - 1];
+    if (index === 0 || prev == null || item[prop] !== prev[prop]) {
       acc.push([item]);
-    } else {
-      acc[acc.length - 1].push(item);
+    } else if (lastGroup) {
+      lastGroup.push(item);
     }
     return acc;
   }, []);

--- a/apps/web/app/features/list/types.ts
+++ b/apps/web/app/features/list/types.ts
@@ -1,0 +1,14 @@
+export type ListItem = {
+  $$id: number;
+  $$visible: boolean;
+  $$hidden: boolean;
+  pageref: string | undefined;
+  startedDateTime: string;
+  time: number;
+  method: string;
+  url: string;
+  status: number;
+  statusText: string;
+};
+
+export type SortField = "url" | "status" | "method" | "time" | "pageref";

--- a/apps/web/app/store/store.ts
+++ b/apps/web/app/store/store.ts
@@ -1,5 +1,6 @@
 import type React from "react";
 import type { Har } from "@repo/har-types";
+import type { SortField } from "../features/list/types";
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 import type { JsonViewerSettings } from "@repo/formatter-core";
@@ -26,8 +27,10 @@ export type Filter = {
   };
 };
 
+export type { SortField };
+
 export type Sorting = {
-  sortBy?: "url" | "status" | "method" | "time" | "pageref";
+  sortBy?: SortField;
   sortDir: "asc" | "desc";
   sortInsidePages: boolean;
 };


### PR DESCRIPTION
## Summary

Phase 1 mitigation for Agent 1 audit findings (issues #1, #2, #7).

- Introduces `ListItem` and `SortField` types in `features/list/types.ts`
- `deriveListData.ts` now returns `ListItem[]` instead of `any[]`
- `filter.ts` — `markVisible` and `resolveVectors` typed with `ListItem`; `resolveToken` widened to handle all `ListItem` value types
- `groupByProperty.ts` converted to a proper generic `<T>(items: T[], prop: keyof T): T[][]`
- `sortItemsArray` in `List.tsx` narrowed from `string` to `SortField`
- `store.ts` and `actions.ts` import `SortField` from `types.ts` — removes duplicated inline union
- All list component props (`ListItem`, `ListItems`, `HiddenItemsGroup`, `PageRef`, `PageRefGroup`) typed via `ListItem` instead of `any`
- Bonus fix: `parseInt(status)` replaced with direct numeric comparison now that `status` is typed as `number`

Closes #68

Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>