### PR TITLE
refactor(web): ban explicit any via ESLint rule with Phase 2 suppressions

### DIFF
--- a/apps/web/.eslintrc.js
+++ b/apps/web/.eslintrc.js
@@ -7,6 +7,9 @@ module.exports = {
     project: true,
   },
   ignorePatterns: ["out/", ".next/"],
+  rules: {
+    "@typescript-eslint/no-explicit-any": "error",
+  },
   overrides: [
     {
       files: ["**/*.test.ts", "**/*.test.tsx"],

--- a/apps/web/app/components/Collapsible.tsx
+++ b/apps/web/app/components/Collapsible.tsx
@@ -16,6 +16,7 @@ export function Collapsible({
   activeActionId = "",
   onAction = () => {},
 }: {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   children: any;
   title?: string | React.JSX.Element;
   handler?: React.JSX.Element;
@@ -24,6 +25,7 @@ export function Collapsible({
   disabled?: boolean;
   active?: boolean;
   sticky?: boolean;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   actions?: { [id: string]: Formatter<any> } | null;
   activeActionId?: string;
   onAction?: (id: string) => void;

--- a/apps/web/app/core/helpers/parseJsonData.ts
+++ b/apps/web/app/core/helpers/parseJsonData.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function parseJsonData(str: string): any {
   if (typeof str !== "string" || !str.length) {
     return null;

--- a/apps/web/app/core/hooks/useDarkMode.ts
+++ b/apps/web/app/core/hooks/useDarkMode.ts
@@ -3,6 +3,7 @@ import { useSyncExternalStore, useCallback } from "react";
 export function useDarkMode() {
   const query = "(prefers-color-scheme: dark)";
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const subscribe = useCallback((callback: () => any) => {
     const matchMedia: MediaQueryList = window.matchMedia(query);
     matchMedia.addEventListener("change", callback);

--- a/apps/web/app/features/detail/components/Content.tsx
+++ b/apps/web/app/features/detail/components/Content.tsx
@@ -8,6 +8,7 @@ import { TextContent } from "@repo/ui/text-content";
 import { CollapsibleTitle } from "../../../components/CollapsibleTitle";
 import { Collapsible } from "../../../components/Collapsible";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function Content({ data }: { data: any }) {
   const { headers, content, bodySize } = data;
 

--- a/apps/web/app/features/detail/components/CooTab.tsx
+++ b/apps/web/app/features/detail/components/CooTab.tsx
@@ -4,6 +4,7 @@ import { CollapsibleTitle } from "../../../components/CollapsibleTitle";
 import { Cookies } from "./Cookies";
 import { NoContent } from "@repo/ui/no-content";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function CooTab({ data }: { data: any }): React.JSX.Element {
   const { cookies } = data;
   const { request, response } = cookies;

--- a/apps/web/app/features/detail/components/Cookies.tsx
+++ b/apps/web/app/features/detail/components/Cookies.tsx
@@ -3,6 +3,7 @@ import { DateTime } from "@repo/ui/date-time";
 import { TrueFalseMark } from "@repo/ui/true-false-mark";
 import { formatDateTime } from "../../../core/helpers/formatDateTime";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function Cookies({ data }: { data: any }): React.JSX.Element {
   return (
     <table className="w-full text-sm">
@@ -20,6 +21,7 @@ export function Cookies({ data }: { data: any }): React.JSX.Element {
       </thead>
 
       <tbody>
+        {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
         {data.map((cookie: any, index: number) => {
           const {
             name,

--- a/apps/web/app/features/detail/components/Headers.tsx
+++ b/apps/web/app/features/detail/components/Headers.tsx
@@ -5,6 +5,7 @@ import { Collapsible } from "../../../components/Collapsible";
 import { CollapsibleTitle } from "../../../components/CollapsibleTitle";
 import { NoContent } from "@repo/ui/no-content";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function Headers({ data }: { data: any }) {
   const { headers, headersSize } = data;
 

--- a/apps/web/app/features/detail/components/ReqTab.tsx
+++ b/apps/web/app/features/detail/components/ReqTab.tsx
@@ -1,6 +1,7 @@
 import { Headers } from "./Headers";
 import { Content } from "./Content";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function ReqTab({ data }: { data: any }) {
   return (
     <div className="mr-2 flex flex-col gap-2">

--- a/apps/web/app/features/detail/components/ResTab.tsx
+++ b/apps/web/app/features/detail/components/ResTab.tsx
@@ -2,6 +2,7 @@ import type React from "react";
 import { Headers } from "./Headers";
 import { Content } from "./Content";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function ResTab({ data }: { data: any }): React.JSX.Element {
   return (
     <div className="mr-2 flex flex-col gap-2">

--- a/apps/web/app/features/detail/components/TimTab.tsx
+++ b/apps/web/app/features/detail/components/TimTab.tsx
@@ -5,6 +5,7 @@ import { NoContent } from "@repo/ui/no-content";
 import { TimingBar } from "./TimingBar";
 import { TimingTable } from "./TimingTable";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function TimTab({ data }: { data: any }): React.JSX.Element {
   const { timings, totalTime } = data;
   const [hoveredKey, setHoveredKey] = useState<string | null>(null);

--- a/apps/web/app/features/detail/helpers/deriveCommonData.test.ts
+++ b/apps/web/app/features/detail/helpers/deriveCommonData.test.ts
@@ -32,6 +32,7 @@ describe("deriveCommonData", () => {
 
   it("passes through undefined optional fields", () => {
     const entry = makeEntry();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     delete (entry as any).serverIPAddress;
     const result = deriveCommonData(entry);
     expect(result.serverIPAddress).toBeUndefined();

--- a/apps/web/app/features/detail/helpers/deriveCommonData.ts
+++ b/apps/web/app/features/detail/helpers/deriveCommonData.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function deriveCommonData(entry: any): any {
   if (!entry) return null;
 

--- a/apps/web/app/features/detail/helpers/deriveTabData.ts
+++ b/apps/web/app/features/detail/helpers/deriveTabData.ts
@@ -1,5 +1,6 @@
 import { TabCode } from "../../../store/store";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function deriveTabData(entry: any, tabCode: TabCode): any {
   if (!entry) return null;
 

--- a/apps/web/app/features/file/components/FileOpener.tsx
+++ b/apps/web/app/features/file/components/FileOpener.tsx
@@ -21,8 +21,10 @@ export const FileOpener = ({ children }: { children?: React.ReactNode }) => {
   let trigger: React.ReactNode = null;
 
   if (React.isValidElement(children)) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const childProps = (children.props as any) || {};
     const existingOnClick = childProps.onClick;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const mergedOnClick = (e?: any) => {
       try {
         existingOnClick && existingOnClick(e);

--- a/apps/web/app/features/file/components/FileTabs.tsx
+++ b/apps/web/app/features/file/components/FileTabs.tsx
@@ -11,6 +11,7 @@ export function FileTabs(): React.JSX.Element {
 
   return (
     <div className="ml-8 flex h-full flex-row gap-2">
+      {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
       {files.map((file: any) => {
         return <FileTab key={file.fileId} file={file} />;
       })}

--- a/apps/web/app/features/footer/helpers/deriveFooterData.ts
+++ b/apps/web/app/features/footer/helpers/deriveFooterData.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function deriveFooterData(harData: any, fileSize: number): any {
   if (!harData) return null;
 
@@ -10,6 +11,7 @@ export function deriveFooterData(harData: any, fileSize: number): any {
     creatorVersion: creator?.version,
     entriesNum: entries?.length || 0,
     totalTime: (
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       entries?.reduce((acc: number, entry: any) => acc + entry.time, 0) || 0
     ).toFixed(2),
   };

--- a/apps/web/app/features/header/components/AppHeaderActions.tsx
+++ b/apps/web/app/features/header/components/AppHeaderActions.tsx
@@ -121,6 +121,7 @@ export function AppHeaderActions(): React.JSX.Element {
 
           <ActionText>Detail</ActionText>
 
+          {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
           {Object.entries(formatters).map(([key, formatter]: [string, any]) => (
             <ActionIcon
               key={key}

--- a/apps/web/app/features/list/helpers/filter.ts
+++ b/apps/web/app/features/list/helpers/filter.ts
@@ -24,6 +24,7 @@ import type { ListItem } from "../types";
 const getTokenVectors = (fields: Filter["fields"]) =>
   Object.entries(fields).reduce(resolveFields, []);
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const resolveFields = (acc: any[], field: [string, string]) => {
   const [fieldName, searchPhrase] = field;
   const phraseParts: string[] = splitSearchPhrase(searchPhrase);
@@ -89,6 +90,7 @@ export const markVisible = (fields: Filter["fields"]) => {
 export const reduceData = (fields: Filter["fields"]) => {
   const tokenVectors = getTokenVectors(fields);
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return (acc: any, listItem: any, index: number, arr: any[]): any => {
     const shouldBeVisible =
       tokenVectors.length < 1 ||

--- a/apps/web/app/features/settings/components/SettingsList.tsx
+++ b/apps/web/app/features/settings/components/SettingsList.tsx
@@ -7,12 +7,14 @@ import { SettingItem } from "./SettingsModal";
 type Props = {
   items: SettingItem[];
   form: AppSettings;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   onChange: (key: keyof AppSettings, value?: any) => void;
 };
 
 type SettingComponentProps = {
   label: string;
   value: unknown;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   onChange: (value?: any) => void;
 };
 
@@ -97,7 +99,9 @@ export default function SettingsList({ items, form, onChange }: Props) {
         <div className="mt-1">
           <Renderer
             label={it.label}
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
             value={value as any}
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
             onChange={(v: any) => onChange(it.key, v)}
           />
         </div>

--- a/apps/web/app/features/settings/components/SettingsModal.tsx
+++ b/apps/web/app/features/settings/components/SettingsModal.tsx
@@ -49,6 +49,7 @@ export default function SettingsModal({ open, onClose }: Props) {
     if (open) setForm(initialForm);
   }, [open, initialForm]);
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const setFormValue = (key: keyof AppSettings, value: any) =>
     setForm((f) => ({ ...(f as AppSettings), [key]: value }) as AppSettings);
 

--- a/apps/web/app/plugins.config.ts
+++ b/apps/web/app/plugins.config.ts
@@ -27,6 +27,7 @@ type Registration<T> = {
   formatters: Formatter<T>[];
 };
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const registrations: Registration<any>[] = [
   {
     registry: contentValueFormatters as Registry<ContentValue>,
@@ -44,6 +45,7 @@ const registrations: Registration<any>[] = [
     formatters: [userAgentParseFormatter, userAgentRawFormatter],
   },
   {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registry: detailFormatters as Registry<any>,
     key: "detail",
     formatters: [detailEnhancedFormatter, detailRawFormatter],

--- a/apps/web/app/plugins/detail-enhanced-formatter/index.tsx
+++ b/apps/web/app/plugins/detail-enhanced-formatter/index.tsx
@@ -2,6 +2,7 @@ import type React from "react";
 import { Formatter } from "@repo/formatter-core";
 import { Detail } from "../../features/detail/components/Detail";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const detailEnhancedFormatter: Formatter<any> = {
   id: "detail-enhanced-formatter",
   title: "Table",

--- a/apps/web/app/plugins/detail-raw-formatter/index.tsx
+++ b/apps/web/app/plugins/detail-raw-formatter/index.tsx
@@ -2,11 +2,13 @@ import type React from "react";
 import { Formatter } from "@repo/formatter-core";
 import { JsonView } from "@repo/formatter-ui/json-view";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const detailRawFormatter: Formatter<any> = {
   id: "detail-raw-formatter",
   title: "Raw",
   icon: "iconify material-symbols--code-blocks-outline-rounded",
   tooltip: "Detail raw view",
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   format: (data: any): React.JSX.Element | string => {
     return <JsonView data={data} collapseBtns={true} />;
   },

--- a/apps/web/app/providers/detailFormatter.ts
+++ b/apps/web/app/providers/detailFormatter.ts
@@ -3,6 +3,7 @@ import { FormatterProvider } from "@repo/formatter-core/registry";
 import { detailEnhancedFormatter } from "../plugins/detail-enhanced-formatter";
 import { detailRawFormatter } from "../plugins/detail-raw-formatter";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const detailFormatters = FormatterProvider<Formatter<any>>();
 
 detailFormatters.addFormatters("detail", [detailEnhancedFormatter]);

--- a/apps/web/app/store/store.ts
+++ b/apps/web/app/store/store.ts
@@ -148,6 +148,7 @@ export const useAppStore = create<AppState>()(
   persist<AppState>(() => initialState, {
     name: "har-viewer-settings",
     // storage may be undefined during SSR; cast to any to satisfy typings
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     storage: settingsStorage as any,
     partialize: (state: AppState) => ({
       uiPersistent: state.uiPersistent,
@@ -165,5 +166,6 @@ export const useAppStore = create<AppState>()(
         ...(persistedState as Partial<AppState>).settings,
       },
     }),
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } as any),
 );


### PR DESCRIPTION
## Summary

Phase 1 mitigation for Agent 1 audit finding #9.

- Adds `@typescript-eslint/no-explicit-any: error` to `apps/web/.eslintrc.js` — all new code is immediately protected
- Adds `eslint-disable-next-line` suppressions on 35 existing violations across Phase 2 scope: detail tab components, store persist middleware, settings, deprecated filter code, plugins, and utility hooks
- Each suppression will be removed by its corresponding Phase 2 PR as those areas get properly typed

Closes #70

Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>