### PR TITLE
refactor(web): introduce detail DTO layer with typed tab and common data shapes

### DIFF
--- a/apps/web/app/features/detail/components/Content.tsx
+++ b/apps/web/app/features/detail/components/Content.tsx
@@ -1,4 +1,5 @@
 import type React from "react";
+import type { ReqTabData, ResTabData } from "../types";
 import { findHeader } from "../../../core/helpers/findHeader";
 import { parseMimeType } from "../../../core/helpers/parseMimeType";
 import { contentValueFormatters } from "@repo/formatter-core/registry";
@@ -8,12 +9,10 @@ import { TextContent } from "@repo/ui/text-content";
 import { CollapsibleTitle } from "../../../components/CollapsibleTitle";
 import { Collapsible } from "../../../components/Collapsible";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function Content({ data }: { data: any }) {
+export function Content({ data }: { data: ReqTabData | ResTabData }) {
   const { headers, content, bodySize } = data;
 
-  const contentType: { name: string; value: string } =
-    headers?.find(findHeader("Content-Type")) || {};
+  const contentType = headers.find(findHeader("Content-Type")) ?? { name: "", value: "" };
 
   const mimeType = parseMimeType(contentType.value);
 
@@ -26,7 +25,7 @@ export function Content({ data }: { data: any }) {
   const info = [contentType.value, size].filter(Boolean).join(" | ");
   const title = <CollapsibleTitle title={"Content"} info={info} />;
 
-  let ContentValue = <TextContent data={content} />;
+  let ContentValue = <TextContent data={content ?? ""} />;
 
   if (!content) {
     ContentValue = <NoContent showIcon={false}>No Content</NoContent>;

--- a/apps/web/app/features/detail/components/CooTab.tsx
+++ b/apps/web/app/features/detail/components/CooTab.tsx
@@ -1,11 +1,11 @@
 import type React from "react";
+import type { CooTabData } from "../types";
 import { Collapsible } from "../../../components/Collapsible";
 import { CollapsibleTitle } from "../../../components/CollapsibleTitle";
 import { Cookies } from "./Cookies";
 import { NoContent } from "@repo/ui/no-content";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function CooTab({ data }: { data: any }): React.JSX.Element {
+export function CooTab({ data }: { data: CooTabData }): React.JSX.Element {
   const { cookies } = data;
   const { request, response } = cookies;
 

--- a/apps/web/app/features/detail/components/Cookies.tsx
+++ b/apps/web/app/features/detail/components/Cookies.tsx
@@ -1,10 +1,10 @@
 import type React from "react";
+import type { Cookie } from "@repo/har-types";
 import { DateTime } from "@repo/ui/date-time";
 import { TrueFalseMark } from "@repo/ui/true-false-mark";
 import { formatDateTime } from "../../../core/helpers/formatDateTime";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function Cookies({ data }: { data: any }): React.JSX.Element {
+export function Cookies({ data }: { data: Cookie[] }): React.JSX.Element {
   return (
     <table className="w-full text-sm">
       <thead className="dark:bg-bunker-950 dark:border-bunker-400 sticky top-0 border-b border-slate-100 bg-slate-50 text-xs font-bold uppercase">
@@ -21,8 +21,7 @@ export function Cookies({ data }: { data: any }): React.JSX.Element {
       </thead>
 
       <tbody>
-        {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-        {data.map((cookie: any, index: number) => {
+        {data.map((cookie, index: number) => {
           const {
             name,
             value,
@@ -44,14 +43,14 @@ export function Cookies({ data }: { data: any }): React.JSX.Element {
               <td className="break-all px-2 py-1">{path ?? ""}</td>
               <td className="break-all px-2 py-1">{domain ?? ""}</td>
               <td className="px-2 py-1 text-center">
-                <DateTime value={formatDateTime(expires, false)} />
+                {expires != null && <DateTime value={formatDateTime(expires, false)} />}
               </td>
               <td className="px-2 py-1 text-center">{sameSite ?? ""}</td>
               <td className="px-2 py-1 text-center">
-                <TrueFalseMark value={httpOnly} />
+                <TrueFalseMark value={httpOnly ?? false} />
               </td>
               <td className="p-2 text-center">
-                <TrueFalseMark value={secure} />
+                <TrueFalseMark value={secure ?? false} />
               </td>
             </tr>
           );

--- a/apps/web/app/features/detail/components/Detail.tsx
+++ b/apps/web/app/features/detail/components/Detail.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from "react";
+import type { ReqTabData, ResTabData, CooTabData, TimTabData } from "../types";
 import { useAppStore } from "../../../store/store";
 import { selectTab } from "../selectors";
 import { selectRawEntry } from "../../../core/selectors";
@@ -21,10 +22,10 @@ export function Detail(): React.JSX.Element {
       <DetailCommon />
       <DetailButtons />
       <DetailSegment>
-        {tab === "REQ" && <ReqTab data={tabData} />}
-        {tab === "RES" && <ResTab data={tabData} />}
-        {tab === "COO" && <CooTab data={tabData} />}
-        {tab === "TIM" && <TimTab data={tabData} />}
+        {tab === "REQ" && tabData && <ReqTab data={tabData as ReqTabData} />}
+        {tab === "RES" && tabData && <ResTab data={tabData as ResTabData} />}
+        {tab === "COO" && tabData && <CooTab data={tabData as CooTabData} />}
+        {tab === "TIM" && tabData && <TimTab data={tabData as TimTabData} />}
       </DetailSegment>
     </>
   );

--- a/apps/web/app/features/detail/components/Headers.tsx
+++ b/apps/web/app/features/detail/components/Headers.tsx
@@ -1,12 +1,12 @@
 import type React from "react";
+import type { ReqTabData, ResTabData } from "../types";
 import { headersFormatters } from "@repo/formatter-core/registry";
 import { useFormatterSelection } from "@repo/formatter-core";
 import { Collapsible } from "../../../components/Collapsible";
 import { CollapsibleTitle } from "../../../components/CollapsibleTitle";
 import { NoContent } from "@repo/ui/no-content";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function Headers({ data }: { data: any }) {
+export function Headers({ data }: { data: ReqTabData | ResTabData }) {
   const { headers, headersSize } = data;
 
   const formatterList = headersFormatters.getFormatters("headers");

--- a/apps/web/app/features/detail/components/ReqTab.tsx
+++ b/apps/web/app/features/detail/components/ReqTab.tsx
@@ -1,8 +1,8 @@
+import type { ReqTabData } from "../types";
 import { Headers } from "./Headers";
 import { Content } from "./Content";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function ReqTab({ data }: { data: any }) {
+export function ReqTab({ data }: { data: ReqTabData }) {
   return (
     <div className="mr-2 flex flex-col gap-2">
       <Headers data={data} />

--- a/apps/web/app/features/detail/components/ResTab.tsx
+++ b/apps/web/app/features/detail/components/ResTab.tsx
@@ -1,9 +1,9 @@
 import type React from "react";
+import type { ResTabData } from "../types";
 import { Headers } from "./Headers";
 import { Content } from "./Content";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function ResTab({ data }: { data: any }): React.JSX.Element {
+export function ResTab({ data }: { data: ResTabData }): React.JSX.Element {
   return (
     <div className="mr-2 flex flex-col gap-2">
       <Headers data={data} />

--- a/apps/web/app/features/detail/components/TimTab.tsx
+++ b/apps/web/app/features/detail/components/TimTab.tsx
@@ -1,12 +1,12 @@
 "use client";
 import { useState } from "react";
 import type React from "react";
+import type { TimTabData } from "../types";
 import { NoContent } from "@repo/ui/no-content";
 import { TimingBar } from "./TimingBar";
 import { TimingTable } from "./TimingTable";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function TimTab({ data }: { data: any }): React.JSX.Element {
+export function TimTab({ data }: { data: TimTabData }): React.JSX.Element {
   const { timings, totalTime } = data;
   const [hoveredKey, setHoveredKey] = useState<string | null>(null);
 

--- a/apps/web/app/features/detail/helpers/deriveCommonData.test.ts
+++ b/apps/web/app/features/detail/helpers/deriveCommonData.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import type { Entry } from "@repo/har-types";
 import { deriveCommonData } from "./deriveCommonData";
 
 const makeEntry = (overrides = {}) => ({
@@ -17,7 +18,7 @@ describe("deriveCommonData", () => {
   });
 
   it("extracts expected fields from a valid entry", () => {
-    const result = deriveCommonData(makeEntry());
+    const result = deriveCommonData(makeEntry() as unknown as Entry);
     expect(result).toEqual({
       status: 200,
       statusText: "OK",
@@ -31,10 +32,9 @@ describe("deriveCommonData", () => {
   });
 
   it("passes through undefined optional fields", () => {
-    const entry = makeEntry();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    delete (entry as any).serverIPAddress;
+    const entry = makeEntry() as unknown as Entry;
+    delete entry.serverIPAddress;
     const result = deriveCommonData(entry);
-    expect(result.serverIPAddress).toBeUndefined();
+    expect(result?.serverIPAddress).toBeUndefined();
   });
 });

--- a/apps/web/app/features/detail/helpers/deriveCommonData.ts
+++ b/apps/web/app/features/detail/helpers/deriveCommonData.ts
@@ -1,10 +1,21 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function deriveCommonData(entry: any): any {
+import type { Entry } from "@repo/har-types";
+import type { CommonData } from "../types";
+
+export function deriveCommonData(entry: Entry | null | undefined): CommonData | null {
   if (!entry) return null;
 
   const { request, response, serverIPAddress, time, _securityState } = entry;
   const { method, url, httpVersion } = request;
   const { status, statusText } = response;
 
-  return { status, statusText, url, method, serverIPAddress, time, httpVersion, _securityState };
+  return {
+    status,
+    statusText,
+    url,
+    method,
+    serverIPAddress,
+    time,
+    httpVersion,
+    _securityState: _securityState as string | null | undefined,
+  };
 }

--- a/apps/web/app/features/detail/helpers/deriveTabData.ts
+++ b/apps/web/app/features/detail/helpers/deriveTabData.ts
@@ -1,40 +1,44 @@
+import type { Entry } from "@repo/har-types";
+import type { ReqTabData, ResTabData, CooTabData, TimTabData } from "../types";
 import { TabCode } from "../../../store/store";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function deriveTabData(entry: any, tabCode: TabCode): any {
+export function deriveTabData(
+  entry: Entry | null,
+  tabCode: TabCode,
+): ReqTabData | ResTabData | CooTabData | TimTabData | null {
   if (!entry) return null;
 
   const { request, response, timings } = entry;
 
   if (tabCode === "REQ") {
     return {
-      headers: request?.headers,
-      headersSize: request?.headersSize,
-      bodySize: request?.bodySize,
-      content: request?.postData?.text,
+      headers: request.headers,
+      headersSize: request.headersSize,
+      bodySize: request.bodySize,
+      content: request.postData?.text,
     };
   }
 
   if (tabCode === "RES") {
     return {
-      headers: response?.headers,
-      headersSize: response?.headersSize,
-      bodySize: response?.bodySize,
-      content: response?.content?.text,
+      headers: response.headers,
+      headersSize: response.headersSize,
+      bodySize: response.bodySize,
+      content: response.content?.text,
     };
   }
 
   if (tabCode === "COO") {
     return {
       cookies: {
-        request: request?.cookies,
-        response: response?.cookies,
+        request: request.cookies,
+        response: response.cookies,
       },
     };
   }
 
   if (tabCode === "TIM") {
-    return { timings, totalTime: entry.time };
+    return { timings: timings as unknown as Record<string, number>, totalTime: entry.time };
   }
 
   return null;

--- a/apps/web/app/features/detail/types.ts
+++ b/apps/web/app/features/detail/types.ts
@@ -1,0 +1,38 @@
+import type { Entry } from "@repo/har-types";
+
+export type ReqTabData = {
+  headers: Entry["request"]["headers"];
+  headersSize: Entry["request"]["headersSize"];
+  bodySize: Entry["request"]["bodySize"];
+  content: string | undefined;
+};
+
+export type ResTabData = {
+  headers: Entry["response"]["headers"];
+  headersSize: Entry["response"]["headersSize"];
+  bodySize: Entry["response"]["bodySize"];
+  content: string | undefined;
+};
+
+export type CooTabData = {
+  cookies: {
+    request: Entry["request"]["cookies"];
+    response: Entry["response"]["cookies"];
+  };
+};
+
+export type TimTabData = {
+  timings: Record<string, number>;
+  totalTime: Entry["time"];
+};
+
+export type CommonData = {
+  status: Entry["response"]["status"];
+  statusText: Entry["response"]["statusText"];
+  url: Entry["request"]["url"];
+  method: Entry["request"]["method"];
+  serverIPAddress: Entry["serverIPAddress"];
+  time: Entry["time"];
+  httpVersion: Entry["request"]["httpVersion"];
+  _securityState: string | null | undefined;
+};


### PR DESCRIPTION
## Summary
- Adds `apps/web/app/features/detail/types.ts` defining `ReqTabData`, `ResTabData`, `CooTabData`, `TimTabData`, and `CommonData` types using indexed access types from `Entry` in `@repo/har-types`
- Updates `deriveTabData` and `deriveCommonData` to accept typed `Entry | null` input and return the new named types instead of `any`
- Propagates types into all detail tab components: `ReqTab`, `ResTab`, `CooTab`, `TimTab`, `Headers`, `Content`, `Cookies`
- Fixes latent type issues uncovered by the stricter types: `content ?? ""` for `TextContent`, `expires != null` guard for `DateTime`, `?? false` for `TrueFalseMark` boolean props
- Removes all 11 `eslint-disable-next-line @typescript-eslint/no-explicit-any` suppressions from the detail feature (PR D scope from issue #72)

Closes #72 (PR D)

Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>