### PR TITLE
refactor(web): type component props and plugin formatters, remove any suppressions

### DIFF
--- a/apps/web/app/components/Collapsible.tsx
+++ b/apps/web/app/components/Collapsible.tsx
@@ -1,7 +1,6 @@
 "use client";
 import React, { useState } from "react";
 import { ToggleMark } from "../features/settings/components/ToggleMark";
-import { Formatter } from "@repo/formatter-core";
 
 export function Collapsible({
   children,
@@ -16,8 +15,7 @@ export function Collapsible({
   activeActionId = "",
   onAction = () => {},
 }: {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  children: any;
+  children: React.ReactNode;
   title?: string | React.JSX.Element;
   handler?: React.JSX.Element;
   initOpen?: boolean;
@@ -25,8 +23,7 @@ export function Collapsible({
   disabled?: boolean;
   active?: boolean;
   sticky?: boolean;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  actions?: { [id: string]: Formatter<any> } | null;
+  actions?: { [id: string]: { id: string; icon: string } } | null;
   activeActionId?: string;
   onAction?: (id: string) => void;
 }) {

--- a/apps/web/app/core/hooks/useDarkMode.ts
+++ b/apps/web/app/core/hooks/useDarkMode.ts
@@ -3,8 +3,7 @@ import { useSyncExternalStore, useCallback } from "react";
 export function useDarkMode() {
   const query = "(prefers-color-scheme: dark)";
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const subscribe = useCallback((callback: () => any) => {
+  const subscribe = useCallback((callback: () => void) => {
     const matchMedia: MediaQueryList = window.matchMedia(query);
     matchMedia.addEventListener("change", callback);
     return () => matchMedia.removeEventListener("change", callback);

--- a/apps/web/app/features/file/components/FileOpener.tsx
+++ b/apps/web/app/features/file/components/FileOpener.tsx
@@ -21,11 +21,9 @@ export const FileOpener = ({ children }: { children?: React.ReactNode }) => {
   let trigger: React.ReactNode = null;
 
   if (React.isValidElement(children)) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const childProps = (children.props as any) || {};
-    const existingOnClick = childProps.onClick;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const mergedOnClick = (e?: any) => {
+    const childProps = (children.props as Record<string, unknown>);
+    const existingOnClick = childProps.onClick as ((e?: unknown) => void) | undefined;
+    const mergedOnClick = (e?: unknown) => {
       try {
         existingOnClick && existingOnClick(e);
       } finally {

--- a/apps/web/app/features/file/components/FileTabs.tsx
+++ b/apps/web/app/features/file/components/FileTabs.tsx
@@ -11,8 +11,7 @@ export function FileTabs(): React.JSX.Element {
 
   return (
     <div className="ml-8 flex h-full flex-row gap-2">
-      {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-      {files.map((file: any) => {
+      {files.map((file) => {
         return <FileTab key={file.fileId} file={file} />;
       })}
     </div>

--- a/apps/web/app/features/header/components/AppHeaderActions.tsx
+++ b/apps/web/app/features/header/components/AppHeaderActions.tsx
@@ -121,8 +121,7 @@ export function AppHeaderActions(): React.JSX.Element {
 
           <ActionText>Detail</ActionText>
 
-          {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-          {Object.entries(formatters).map(([key, formatter]: [string, any]) => (
+          {Object.entries(formatters).map(([key, formatter]) => (
             <ActionIcon
               key={key}
               active={key === detailFormatterId}

--- a/apps/web/app/features/settings/components/SettingsList.tsx
+++ b/apps/web/app/features/settings/components/SettingsList.tsx
@@ -2,20 +2,18 @@
 import React from "react";
 import type { Settings as AppSettings } from "../../../store/store";
 import ToggleSwitch from "@repo/ui/toggle-switch";
-import { SettingItem } from "./SettingsModal";
+import { SettingItem, SettingValue } from "./SettingsModal";
 
 type Props = {
   items: SettingItem[];
   form: AppSettings;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  onChange: (key: keyof AppSettings, value?: any) => void;
+  onChange: (key: keyof AppSettings, value: SettingValue) => void;
 };
 
 type SettingComponentProps = {
   label: string;
   value: unknown;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  onChange: (value?: any) => void;
+  onChange: (value: SettingValue) => void;
 };
 
 const SwitchRenderer: React.FC<SettingComponentProps> = ({
@@ -99,10 +97,8 @@ export default function SettingsList({ items, form, onChange }: Props) {
         <div className="mt-1">
           <Renderer
             label={it.label}
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            value={value as any}
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            onChange={(v: any) => onChange(it.key, v)}
+            value={value}
+            onChange={(v) => onChange(it.key, v ?? null)}
           />
         </div>
       </div>

--- a/apps/web/app/features/settings/components/SettingsModal.tsx
+++ b/apps/web/app/features/settings/components/SettingsModal.tsx
@@ -12,6 +12,8 @@ type Props = {
   onClose: () => void;
 };
 
+export type SettingValue = boolean | string | number | null;
+
 export type SettingItem = {
   key: keyof AppSettings;
   label: string;
@@ -49,8 +51,7 @@ export default function SettingsModal({ open, onClose }: Props) {
     if (open) setForm(initialForm);
   }, [open, initialForm]);
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const setFormValue = (key: keyof AppSettings, value: any) =>
+  const setFormValue = (key: keyof AppSettings, value: SettingValue) =>
     setForm((f) => ({ ...(f as AppSettings), [key]: value }) as AppSettings);
 
   const resetToDefaults = () => setForm({ ...initialSettings });

--- a/apps/web/app/plugins.config.ts
+++ b/apps/web/app/plugins.config.ts
@@ -21,45 +21,16 @@ type Registry<T> = {
   addFormatters: (key: string, formatters: Formatter<T>[]) => void;
 };
 
-type Registration<T> = {
-  registry: Registry<T>;
-  key: string;
-  formatters: Formatter<T>[];
-};
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const registrations: Registration<any>[] = [
-  {
-    registry: contentValueFormatters as Registry<ContentValue>,
-    key: "application/json",
-    formatters: [jsonPrettyFormatter, jsonRawFormatter],
-  },
-  {
-    registry: headersFormatters as Registry<HeaderItem[]>,
-    key: "headers",
-    formatters: [headersTableFormatter, headersPlainFormatter, headersRawFormatter],
-  },
-  {
-    registry: headerValueFormatters as Registry<HeaderItem>,
-    key: "User-Agent",
-    formatters: [userAgentParseFormatter, userAgentRawFormatter],
-  },
-  {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    registry: detailFormatters as Registry<any>,
-    key: "detail",
-    formatters: [detailEnhancedFormatter, detailRawFormatter],
-  },
-];
-
 let bootstrapped = false;
 
 export function bootstrapPlugins(): void {
   if (bootstrapped) return;
   bootstrapped = true;
-  for (const { registry, key, formatters } of registrations) {
-    registry.addFormatters(key, formatters);
-  }
+
+  (contentValueFormatters as Registry<ContentValue>).addFormatters("application/json", [jsonPrettyFormatter, jsonRawFormatter]);
+  (headersFormatters as Registry<HeaderItem[]>).addFormatters("headers", [headersTableFormatter, headersPlainFormatter, headersRawFormatter]);
+  (headerValueFormatters as Registry<HeaderItem>).addFormatters("User-Agent", [userAgentParseFormatter, userAgentRawFormatter]);
+  (detailFormatters as Registry<unknown>).addFormatters("detail", [detailEnhancedFormatter, detailRawFormatter]);
 }
 
 bootstrapPlugins();

--- a/apps/web/app/plugins/detail-enhanced-formatter/index.tsx
+++ b/apps/web/app/plugins/detail-enhanced-formatter/index.tsx
@@ -2,8 +2,7 @@ import type React from "react";
 import { Formatter } from "@repo/formatter-core";
 import { Detail } from "../../features/detail/components/Detail";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const detailEnhancedFormatter: Formatter<any> = {
+export const detailEnhancedFormatter: Formatter<unknown> = {
   id: "detail-enhanced-formatter",
   title: "Table",
   icon: "iconify material-symbols--table-rows-outline",

--- a/apps/web/app/plugins/detail-raw-formatter/index.tsx
+++ b/apps/web/app/plugins/detail-raw-formatter/index.tsx
@@ -2,14 +2,12 @@ import type React from "react";
 import { Formatter } from "@repo/formatter-core";
 import { JsonView } from "@repo/formatter-ui/json-view";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const detailRawFormatter: Formatter<any> = {
+export const detailRawFormatter: Formatter<unknown> = {
   id: "detail-raw-formatter",
   title: "Raw",
   icon: "iconify material-symbols--code-blocks-outline-rounded",
   tooltip: "Detail raw view",
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  format: (data: any): React.JSX.Element | string => {
+  format: (data: unknown): React.JSX.Element | string => {
     return <JsonView data={data} collapseBtns={true} />;
   },
 };

--- a/apps/web/app/providers/detailFormatter.ts
+++ b/apps/web/app/providers/detailFormatter.ts
@@ -3,8 +3,7 @@ import { FormatterProvider } from "@repo/formatter-core/registry";
 import { detailEnhancedFormatter } from "../plugins/detail-enhanced-formatter";
 import { detailRawFormatter } from "../plugins/detail-raw-formatter";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const detailFormatters = FormatterProvider<Formatter<any>>();
+export const detailFormatters = FormatterProvider<Formatter<unknown>>();
 
 detailFormatters.addFormatters("detail", [detailEnhancedFormatter]);
 detailFormatters.addFormatters("detail", [detailRawFormatter]);


### PR DESCRIPTION
## Summary
- `Collapsible.tsx`: types `children` as `React.ReactNode`; types `actions` as a structural `{ id: string; icon: string }` picker, removing the `Formatter<any>` generic dependency
- `useDarkMode.ts`: types `subscribe` callback as `() => void`
- `SettingsModal.tsx`: introduces and exports `SettingValue = boolean | string | number | null` union type; removes `any` from `setFormValue`
- `SettingsList.tsx`: imports `SettingValue`; removes all four `any` annotations from `Props.onChange`, `SettingComponentProps.onChange`, `value` cast, and the inline arrow
- `FileOpener.tsx`: types `childProps` as `Record<string, unknown>` and `mergedOnClick` parameter as `unknown`
- `FileTabs.tsx`: removes explicit `file: any` annotation — TypeScript infers `File` from `selectFiles`
- `AppHeaderActions.tsx`: removes explicit `[string, any]` annotation — TypeScript infers `Formatter<any>` from the registry return type
- `detail-enhanced-formatter`, `detail-raw-formatter`: typed as `Formatter<unknown>`
- `plugins.config.ts`: removes `Registration<any>[]` array; inlines registry calls directly in `bootstrapPlugins()` using per-registry `Registry<T>` casts
- `providers/detailFormatter.ts`: typed as `FormatterProvider<Formatter<unknown>>()`

Removes all 18 `eslint-disable-next-line @typescript-eslint/no-explicit-any` suppressions in PR E scope from issue #72.

Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>