### PR TITLE
refactor(web): type store persist middleware and deriveFooterData (PR F)

### DIFF
--- a/apps/web/app/features/footer/helpers/deriveFooterData.test.ts
+++ b/apps/web/app/features/footer/helpers/deriveFooterData.test.ts
@@ -23,14 +23,14 @@ describe("deriveFooterData", () => {
     expect(result.fileSize).toBe(1024);
   });
 
-  it("computes total time as a fixed-2 string", () => {
+  it("computes total time as a number", () => {
     const result = deriveFooterData(makeHar(), 0);
-    expect(result.totalTime).toBe("350.00");
+    expect(result.totalTime).toBe(350);
   });
 
   it("returns 0 entries and 0 total time when entries is missing", () => {
     const result = deriveFooterData(makeHar({ entries: undefined }), 0);
     expect(result.entriesNum).toBe(0);
-    expect(result.totalTime).toBe("0.00");
+    expect(result.totalTime).toBe(0);
   });
 });

--- a/apps/web/app/features/footer/helpers/deriveFooterData.ts
+++ b/apps/web/app/features/footer/helpers/deriveFooterData.ts
@@ -1,5 +1,15 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function deriveFooterData(harData: any, fileSize: number): any {
+import type { Log } from "@repo/har-types";
+
+export type FooterData = {
+  version: string;
+  fileSize: number;
+  creatorName: string | undefined;
+  creatorVersion: string | undefined;
+  entriesNum: number;
+  totalTime: number;
+};
+
+export function deriveFooterData(harData: Log | null | undefined, fileSize: number): FooterData | null {
   if (!harData) return null;
 
   const { version, creator, entries } = harData;
@@ -10,9 +20,6 @@ export function deriveFooterData(harData: any, fileSize: number): any {
     creatorName: creator?.name,
     creatorVersion: creator?.version,
     entriesNum: entries?.length || 0,
-    totalTime: (
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      entries?.reduce((acc: number, entry: any) => acc + entry.time, 0) || 0
-    ).toFixed(2),
+    totalTime: entries?.reduce((acc: number, entry) => acc + entry.time, 0) || 0,
   };
 }

--- a/apps/web/app/store/store.test.ts
+++ b/apps/web/app/store/store.test.ts
@@ -2,8 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("../plugins.config", () => ({ bootstrapPlugins: vi.fn() }));
 vi.mock("zustand/middleware", () => ({
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  persist: (fn: any) => fn,
+  persist: <T>(fn: T): T => fn,
   createJSONStorage: vi.fn(),
 }));
 

--- a/apps/web/app/store/store.ts
+++ b/apps/web/app/store/store.ts
@@ -3,6 +3,7 @@ import type { Har } from "@repo/har-types";
 import type { SortField } from "../features/list/types";
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
+import type { PersistStorage } from "zustand/middleware";
 import type { JsonViewerSettings } from "@repo/formatter-core";
 import { detailFormatters } from "@repo/formatter-core/registry";
 import "../plugins.config";
@@ -128,9 +129,11 @@ export const initialJsonViewerSettings: JsonViewerSettings = {
   shortenTextAfterLength: 0,
 };
 
-const settingsStorage =
+type PersistedState = Pick<AppState, "uiPersistent" | "settings">;
+
+const settingsStorage: PersistStorage<PersistedState> | undefined =
   typeof window !== "undefined"
-    ? createJSONStorage(() => localStorage)
+    ? (createJSONStorage(() => localStorage) as PersistStorage<PersistedState>)
     : undefined;
 
 const initialState: AppState = {
@@ -145,27 +148,26 @@ const initialState: AppState = {
 };
 
 export const useAppStore = create<AppState>()(
-  persist<AppState>(() => initialState, {
+  persist<AppState, [], [], PersistedState>(() => initialState, {
     name: "har-viewer-settings",
-    // storage may be undefined during SSR; cast to any to satisfy typings
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    storage: settingsStorage as any,
-    partialize: (state: AppState) => ({
+    storage: settingsStorage,
+    partialize: (state: AppState): PersistedState => ({
       uiPersistent: state.uiPersistent,
       settings: state.settings,
     }),
-    merge: (persistedState: Partial<AppState>, currentState: AppState) => ({
-      ...currentState,
-      ...persistedState,
-      uiPersistent: {
-        ...currentState.uiPersistent,
-        ...(persistedState as Partial<AppState>).uiPersistent,
-      },
-      settings: {
-        ...currentState.settings,
-        ...(persistedState as Partial<AppState>).settings,
-      },
-    }),
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } as any),
+    merge: (persistedState: unknown, currentState: AppState): AppState => {
+      const persisted = persistedState as Partial<PersistedState>;
+      return {
+        ...currentState,
+        uiPersistent: {
+          ...currentState.uiPersistent,
+          ...persisted.uiPersistent,
+        },
+        settings: {
+          ...currentState.settings,
+          ...persisted.settings,
+        },
+      };
+    },
+  }),
 );


### PR DESCRIPTION
## Summary
- Define `PersistedState = Pick<AppState, 'uiPersistent' | 'settings'>` and pass it as the 4th type param to `persist<AppState, [], [], PersistedState>` so `partialize`, `storage`, and `merge` are fully typed
- Type `settingsStorage` as `PersistStorage<PersistedState> | undefined` (cast from `createJSONStorage`, not `any`)
- Change `merge` first param from `Partial<AppState>` to `unknown` (matches Zustand's declared signature), cast to `Partial<PersistedState>` inside
- Type `deriveFooterData` with `Log` from `@repo/har-types` and add explicit `FooterData` return type
- Return `totalTime` as `number` instead of a `string` from `toFixed(2)`, fixing the silent coercion in `Footer.tsx` that was hidden by `any`
- Fix `persist` mock in `store.test.ts` to use `<T>(fn: T): T => fn` instead of `(fn: any) => fn`

Removes all 5 remaining `eslint-disable` suppressions for `@typescript-eslint/no-explicit-any` in PR F scope. Closes part of #72.

Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>