### PR TITLE
fix(file): surface contextual error messages on file open failure

### DIFF
--- a/apps/web/app/features/file/components/FileReadError.test.tsx
+++ b/apps/web/app/features/file/components/FileReadError.test.tsx
@@ -1,0 +1,7 @@
+import { render } from "@testing-library/react";
+import { FileReadError } from "./FileReadError";
+
+test("renders without crashing", () => {
+  const { container } = render(<FileReadError name="test.har" reason="The file contains invalid JSON." />);
+  expect(container).not.toBeEmptyDOMElement();
+});

--- a/apps/web/app/features/file/components/FileReadError.tsx
+++ b/apps/web/app/features/file/components/FileReadError.tsx
@@ -1,0 +1,15 @@
+import type React from "react";
+
+type FileReadErrorProps = {
+  name: string;
+  reason: string;
+};
+
+export function FileReadError({ name, reason }: FileReadErrorProps): React.JSX.Element {
+  return (
+    <>
+      File <span className="underline-offset-3 italic underline">{name}</span>{" "}
+      could not be opened. {reason}
+    </>
+  );
+}

--- a/apps/web/app/features/file/helpers/openFile.tsx
+++ b/apps/web/app/features/file/helpers/openFile.tsx
@@ -5,6 +5,7 @@ import { readFileData } from "./readFileData";
 import { addFile, setFileId } from "../actions";
 import { setRowId } from "../../list/actions";
 import { addToast } from "../../notifications/actions";
+import { FileReadError } from "../components/FileReadError";
 
 export async function openFile(file: File, message: string | React.JSX.Element) {
   const { name, size } = file;
@@ -23,10 +24,16 @@ export async function openFile(file: File, message: string | React.JSX.Element) 
     setFileId(fileId);
     setRowId(0);
   } catch (error) {
-    console.error("Error loading file:", error);
+    const reason =
+      error instanceof SyntaxError
+        ? "The file contains invalid HAR format."
+        : error instanceof DOMException
+          ? `Read failed: ${error.message}`
+          : "An unexpected error occurred.";
+
     addToast({
       type: "alert",
-      message,
+      message: <FileReadError name={name} reason={reason} />,
     });
   }
 }


### PR DESCRIPTION
## Summary
- Renamed `openFile.ts` → `openFile.tsx` to allow JSX usage
- Added `FileReadError` component that shows the file name and a user-facing reason
- Replaced silent `console.error` + generic toast in the catch block with contextual messages: invalid HAR format, read failure, or unexpected error
- Added smoke test for `FileReadError`

Closes #72 (Finding 5 — Silent error handling)

Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>