### PR TITLE
refactor(components): replace imperative DOM listeners with React event handlers

### DIFF
--- a/apps/web/app/components/Modal.tsx
+++ b/apps/web/app/components/Modal.tsx
@@ -25,6 +25,7 @@ export default function Modal({
   footer,
 }: ModalProps) {
   const dialogRef = useRef<HTMLDialogElement | null>(null);
+  const startedOnBackdrop = useRef(false);
 
   useEffect(() => {
     const dialog = dialogRef.current;
@@ -60,38 +61,31 @@ export default function Modal({
       onClose();
     };
 
-    // Track if the interaction started on the backdrop.
-    // Only close if both down and up happened on the backdrop.
-    let startedOnBackdrop = false;
-
-    const onPointerDown = (e: PointerEvent) => {
-      if (!closeOnBackdropClick) return;
-      startedOnBackdrop = e.target === dialog;
-    };
-    const onPointerUp = (e: PointerEvent) => {
-      if (!closeOnBackdropClick) return;
-      if (startedOnBackdrop && e.target === dialog) {
-        onClose();
-      }
-      startedOnBackdrop = false;
-    };
-
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") onClose();
     };
 
     dialog.addEventListener("cancel", onCancel);
-    dialog.addEventListener("pointerdown", onPointerDown);
-    dialog.addEventListener("pointerup", onPointerUp);
     window.addEventListener("keydown", onKey);
 
     return () => {
       dialog.removeEventListener("cancel", onCancel);
-      dialog.removeEventListener("pointerdown", onPointerDown);
-      dialog.removeEventListener("pointerup", onPointerUp);
       window.removeEventListener("keydown", onKey);
     };
-  }, [onClose, closeOnBackdropClick]);
+  }, [onClose]);
+
+  const handlePointerDown = (e: React.PointerEvent<HTMLDialogElement>) => {
+    if (!closeOnBackdropClick) return;
+    startedOnBackdrop.current = e.target === dialogRef.current;
+  };
+
+  const handlePointerUp = (e: React.PointerEvent<HTMLDialogElement>) => {
+    if (!closeOnBackdropClick) return;
+    if (startedOnBackdrop.current && e.target === dialogRef.current) {
+      onClose();
+    }
+    startedOnBackdrop.current = false;
+  };
 
   // compute panel class based on size
   const panelBase =
@@ -124,6 +118,8 @@ export default function Modal({
     <dialog
       ref={dialogRef}
       aria-label={title ?? "Dialog"}
+      onPointerDown={handlePointerDown}
+      onPointerUp={handlePointerUp}
       className={
         "fixed inset-0 m-auto border-0 bg-transparent p-0 backdrop:bg-black/60 backdrop:backdrop-blur-sm " +
         className

--- a/apps/web/app/components/SplitPanels.tsx
+++ b/apps/web/app/components/SplitPanels.tsx
@@ -27,29 +27,25 @@ export default function SplitPanels({
   };
 
   const startDrag = (event: React.PointerEvent<HTMLDivElement>) => {
+    event.currentTarget.setPointerCapture(event.pointerId);
+    setIsDragging(true);
+  };
+
+  const onDragMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (!isDragging) return;
     const containerNode = containerRef.current;
     if (!containerNode) return;
 
-    event.currentTarget.setPointerCapture(event.pointerId);
-    setIsDragging(true);
+    const rect = containerNode.getBoundingClientRect();
+    const x = event.clientX - rect.left;
+    let nextPercent = (x / rect.width) * 100;
+    if (nextPercent < minLeftPercent) nextPercent = minLeftPercent;
+    if (nextPercent > maxLeftPercent) nextPercent = maxLeftPercent;
+    setLeftPercent(nextPercent);
+  };
 
-    const onMove = (moveEvent: PointerEvent) => {
-      const rect = containerNode.getBoundingClientRect();
-      const x = moveEvent.clientX - rect.left;
-      let nextPercent = (x / rect.width) * 100;
-      if (nextPercent < minLeftPercent) nextPercent = minLeftPercent;
-      if (nextPercent > maxLeftPercent) nextPercent = maxLeftPercent;
-      setLeftPercent(nextPercent);
-    };
-
-    const onUp = () => {
-      setIsDragging(false);
-      window.removeEventListener("pointermove", onMove);
-      window.removeEventListener("pointerup", onUp);
-    };
-
-    window.addEventListener("pointermove", onMove);
-    window.addEventListener("pointerup", onUp);
+  const stopDrag = () => {
+    setIsDragging(false);
   };
 
   const dividerBase =
@@ -83,6 +79,8 @@ export default function SplitPanels({
         role="separator"
         aria-orientation="vertical"
         onPointerDown={startDrag}
+        onPointerMove={onDragMove}
+        onPointerUp={stopDrag}
         onDoubleClick={resetToCenter}
         onPointerEnter={() => setIsHoveringDivider(true)}
         onPointerLeave={() => setIsHoveringDivider(false)}


### PR DESCRIPTION
## Summary
- `Modal.tsx`: moved `pointerdown`/`pointerup` from `addEventListener` to `onPointerDown`/`onPointerUp` React props on the `<dialog>` element; `startedOnBackdrop` is now a `useRef`; `useEffect` dep array reduced to `[onClose]`
- `SplitPanels.tsx`: pointer capture was already set on drag start, so `pointermove`/`pointerup` moved from `window` listeners to `onPointerMove`/`onPointerUp` React handlers on the divider — eliminates manual cleanup entirely

Closes #72 (Finding 8 — Imperative DOM event listeners)

Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>