### PR TITLE
fix(toast): fix close button hover padding and add fade-out on dismiss

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,10 @@ yarn-error.log*
 # Next.js
 next-env.d.ts
 
+# Playwright
+.playwright/
+.playwright-cli/
+
 # Misc
 .DS_Store
 *.pem

--- a/apps/web/app/features/file/components/FileOpener.tsx
+++ b/apps/web/app/features/file/components/FileOpener.tsx
@@ -5,6 +5,7 @@ import { WrongFile } from "./WrongFile";
 
 const processInputFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
   const file = e.target.files?.[0];
+  e.target.value = "";
   if (!file) {
     return;
   }

--- a/apps/web/app/features/notifications/components/ToastItem.tsx
+++ b/apps/web/app/features/notifications/components/ToastItem.tsx
@@ -1,7 +1,12 @@
 import type React from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { Toast } from "../../../store/store";
 import { removeToast } from "../actions";
 import { useFadeIn } from "../../../core/hooks/useFadeIn";
+
+// How long a toast stays visible before it fades out and is removed (ms)
+const TOAST_AUTO_DISMISS_MS = 15000;
+const FADE_DURATION = 500;
 
 // todo: improve using Toast['type]
 const toastTypesMap: { [key: string]: string } = {
@@ -21,6 +26,23 @@ export function ToastItem({
   icon?: Toast["icon"];
 }): React.JSX.Element {
   const ref = useFadeIn(450, 20);
+  const dismissTimers = useRef<ReturnType<typeof setTimeout>[]>([]);
+
+  const fadeOutAndRemove = useCallback(() => {
+    dismissTimers.current.forEach(clearTimeout);
+    if (ref.current) {
+      ref.current.style.transition = `opacity ${FADE_DURATION}ms ease-out`;
+      ref.current.style.opacity = "0";
+    }
+    dismissTimers.current = [setTimeout(() => removeToast(id), FADE_DURATION)];
+  }, [id]);
+
+  useEffect(() => {
+    const fadeTimer = setTimeout(fadeOutAndRemove, TOAST_AUTO_DISMISS_MS - FADE_DURATION);
+    dismissTimers.current = [fadeTimer];
+
+    return () => dismissTimers.current.forEach(clearTimeout);
+  }, [fadeOutAndRemove]);
 
   return (
     <div
@@ -31,10 +53,10 @@ export function ToastItem({
         <span className={`${icon} text-2xl`}></span>
       </div>
       <div className="my-auto flex-1 p-3">{message}</div>
-      <div className="pb-3 pl-0 pr-2 pt-2">
+      <div className="p-2 pl-0">
         <div
-          className="rounded-md p-1 transition-colors duration-200 hover:bg-black hover:bg-opacity-10"
-          onClick={() => removeToast(id)}
+          className="flex rounded-md p-1 transition-colors duration-200 hover:bg-black hover:bg-opacity-10"
+          onClick={fadeOutAndRemove}
         >
           <span className="iconify material-symbols--close-rounded text-2xl"></span>
         </div>

--- a/apps/web/app/plugins/detail-raw-formatter/index.tsx
+++ b/apps/web/app/plugins/detail-raw-formatter/index.tsx
@@ -2,12 +2,26 @@ import type React from "react";
 import { Formatter } from "@repo/formatter-core";
 import { JsonView } from "@repo/formatter-ui/json-view";
 
+function stripInternalKeys(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(stripInternalKeys);
+  }
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .filter(([key]) => !key.startsWith("$$"))
+        .map(([key, val]) => [key, stripInternalKeys(val)]),
+    );
+  }
+  return value;
+}
+
 export const detailRawFormatter: Formatter<unknown> = {
   id: "detail-raw-formatter",
   title: "Raw",
   icon: "iconify material-symbols--code-blocks-outline-rounded",
   tooltip: "Detail raw view",
   format: (data: unknown): React.JSX.Element | string => {
-    return <JsonView data={data} collapseBtns={true} />;
+    return <JsonView data={stripInternalKeys(data)} collapseBtns={true} />;
   },
 };

--- a/packages/ui/src/line-clamp.tsx
+++ b/packages/ui/src/line-clamp.tsx
@@ -69,7 +69,7 @@ function LineClampInner({
       classes={classes}
       handleClick={handleClick}
     >
-      {expanded ? "...Hide" : label}
+      {expanded ? "...Less" : label}
     </ExpandButton>
   );
 


### PR DESCRIPTION
## Summary
- Fix uneven hover background on toast close button (caused by inline baseline gap and flex stretch)
- Add fade-out animation when clicking X, cancelling auto-dismiss timers to avoid double-remove
- Reset file input value after selection so the same file can be reopened
- Strip internal `$$` keys from raw formatter output
- Update line-clamp expand button label from `...Hide` to `...Less`
- Add Playwright CLI artifacts to `.gitignore`

## Test plan
- [ ] Open a bad HAR file, verify error toast appears
- [ ] Hover close button — background should be evenly padded on all sides
- [ ] Click X — toast should fade out smoothly before disappearing
- [ ] Auto-dismiss should still fade out after 15s

🤖 Generated with [Claude Code](https://claude.com/claude-code)