### PR TITLE
test(web): add behaviour tests for filter, deriveTabData, and deriveListData

### DIFF
--- a/apps/web/app/features/detail/helpers/deriveTabData.test.ts
+++ b/apps/web/app/features/detail/helpers/deriveTabData.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import type { Entry } from "@repo/har-types";
+import { deriveTabData } from "./deriveTabData";
+
+const makeEntry = (overrides: Record<string, unknown> = {}) =>
+  ({
+    request: {
+      method: "GET",
+      url: "https://example.com",
+      httpVersion: "HTTP/1.1",
+      headers: [{ name: "Accept", value: "*/*" }],
+      cookies: [{ name: "sid", value: "abc" }],
+      headersSize: 64,
+      bodySize: 0,
+    },
+    response: {
+      status: 200,
+      statusText: "OK",
+      httpVersion: "HTTP/1.1",
+      headers: [{ name: "Content-Type", value: "application/json" }],
+      cookies: [{ name: "set-sid", value: "xyz" }],
+      headersSize: 128,
+      bodySize: 42,
+      content: { size: 42, mimeType: "application/json", text: '{"ok":true}' },
+    },
+    timings: { send: 1, wait: 50, receive: 5 },
+    time: 56,
+    ...overrides,
+  }) as unknown as Entry;
+
+describe("deriveTabData", () => {
+  it("returns null for null entry", () => {
+    expect(deriveTabData(null, "REQ")).toBeNull();
+  });
+
+  it("returns null for unknown tabCode", () => {
+    expect(deriveTabData(makeEntry(), "UNKNOWN" as never)).toBeNull();
+  });
+
+  describe("REQ tab", () => {
+    it("extracts request headers, sizes, and postData text", () => {
+      const entry = makeEntry({
+        request: {
+          method: "POST",
+          url: "https://example.com",
+          httpVersion: "HTTP/1.1",
+          headers: [{ name: "Content-Type", value: "application/json" }],
+          cookies: [],
+          headersSize: 80,
+          bodySize: 15,
+          postData: { mimeType: "application/json", text: '{"a":1}' },
+        },
+      });
+      const result = deriveTabData(entry, "REQ");
+      expect(result).toEqual({
+        headers: [{ name: "Content-Type", value: "application/json" }],
+        headersSize: 80,
+        bodySize: 15,
+        content: '{"a":1}',
+      });
+    });
+
+    it("returns undefined content when postData is absent", () => {
+      const result = deriveTabData(makeEntry(), "REQ");
+      expect((result as { content: unknown })?.content).toBeUndefined();
+    });
+  });
+
+  describe("RES tab", () => {
+    it("extracts response headers, sizes, and content text", () => {
+      const result = deriveTabData(makeEntry(), "RES");
+      expect(result).toEqual({
+        headers: [{ name: "Content-Type", value: "application/json" }],
+        headersSize: 128,
+        bodySize: 42,
+        content: '{"ok":true}',
+      });
+    });
+
+    it("returns undefined content when response content has no text", () => {
+      const entry = makeEntry();
+      (entry.response.content as Record<string, unknown>).text = undefined;
+      const result = deriveTabData(entry, "RES");
+      expect((result as { content: unknown })?.content).toBeUndefined();
+    });
+  });
+
+  describe("COO tab", () => {
+    it("extracts request and response cookies", () => {
+      const result = deriveTabData(makeEntry(), "COO");
+      expect(result).toEqual({
+        cookies: {
+          request: [{ name: "sid", value: "abc" }],
+          response: [{ name: "set-sid", value: "xyz" }],
+        },
+      });
+    });
+
+    it("handles empty cookie arrays", () => {
+      const entry = makeEntry();
+      entry.request.cookies = [];
+      entry.response.cookies = [];
+      const result = deriveTabData(entry, "COO");
+      expect(result).toEqual({ cookies: { request: [], response: [] } });
+    });
+  });
+
+  describe("TIM tab", () => {
+    it("extracts timings and totalTime", () => {
+      const result = deriveTabData(makeEntry(), "TIM");
+      expect(result).toEqual({
+        timings: { send: 1, wait: 50, receive: 5 },
+        totalTime: 56,
+      });
+    });
+
+    it("preserves totalTime of zero", () => {
+      const entry = makeEntry({ time: 0 });
+      const result = deriveTabData(entry, "TIM");
+      expect((result as { totalTime: number })?.totalTime).toBe(0);
+    });
+  });
+});

--- a/apps/web/app/features/list/helpers/deriveListData.test.ts
+++ b/apps/web/app/features/list/helpers/deriveListData.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import type { Entry } from "@repo/har-types";
+import { deriveListData } from "./deriveListData";
+
+const makeEntry = (overrides: Record<string, unknown> = {}) =>
+  ({
+    pageref: "page_1",
+    startedDateTime: "2024-01-01T00:00:00.000Z",
+    time: 42,
+    request: { method: "GET", url: "https://example.com/api" },
+    response: { status: 200, statusText: "OK" },
+    ...overrides,
+  }) as unknown as Entry;
+
+describe("deriveListData", () => {
+  it("returns empty array for null input", () => {
+    expect(deriveListData(null)).toEqual([]);
+  });
+
+  it("returns empty array for non-array input", () => {
+    expect(deriveListData({} as never)).toEqual([]);
+    expect(deriveListData("string" as never)).toEqual([]);
+  });
+
+  it("returns empty array for an empty entries array", () => {
+    expect(deriveListData([])).toEqual([]);
+  });
+
+  it("maps a single entry to a ListItem with correct fields", () => {
+    const result = deriveListData([makeEntry()]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      $$id: 0,
+      $$visible: false,
+      $$hidden: false,
+      pageref: "page_1",
+      startedDateTime: "2024-01-01T00:00:00.000Z",
+      time: 42,
+      method: "GET",
+      url: "https://example.com/api",
+      status: 200,
+      statusText: "OK",
+    });
+  });
+
+  it("assigns sequential $$id values starting at 0", () => {
+    const entries = [makeEntry(), makeEntry(), makeEntry()];
+    const result = deriveListData(entries);
+    expect(result.map((item) => item.$$id)).toEqual([0, 1, 2]);
+  });
+
+  it("initialises $$visible and $$hidden as false for all items", () => {
+    const result = deriveListData([makeEntry(), makeEntry()]);
+    expect(result.every((item) => item.$$visible === false)).toBe(true);
+    expect(result.every((item) => item.$$hidden === false)).toBe(true);
+  });
+
+  it("passes through undefined pageref", () => {
+    const entry = makeEntry({ pageref: undefined });
+    const result = deriveListData([entry]);
+    expect(result[0].pageref).toBeUndefined();
+  });
+
+  it("preserves each entry's distinct field values", () => {
+    const entries = [
+      makeEntry({ request: { method: "GET", url: "https://a.com" }, response: { status: 200, statusText: "OK" } }),
+      makeEntry({ request: { method: "POST", url: "https://b.com" }, response: { status: 201, statusText: "Created" } }),
+    ];
+    const result = deriveListData(entries);
+    expect(result[0].method).toBe("GET");
+    expect(result[1].method).toBe("POST");
+    expect(result[0].status).toBe(200);
+    expect(result[1].status).toBe(201);
+  });
+});

--- a/apps/web/app/features/list/helpers/filter.test.ts
+++ b/apps/web/app/features/list/helpers/filter.test.ts
@@ -51,4 +51,43 @@ describe("markVisible", () => {
     expect(mark(makeItem()).$$visible).toBe(true);
     expect(mark(makeItem({ method: "POST" })).$$visible).toBe(false);
   });
+
+  it("is case-insensitive for both token and field value", () => {
+    const mark = markVisible(makeFilter({ url: "USERS" }));
+    expect(mark(makeItem({ url: "https://example.com/api/users" })).$$visible).toBe(true);
+    const markLower = markVisible(makeFilter({ url: "users" }));
+    expect(markLower(makeItem({ url: "https://example.com/api/USERS" })).$$visible).toBe(true);
+  });
+
+  it("treats a lone '-' token as a positive match (not a negative)", () => {
+    // token.length > 1 guard — a bare '-' should not exclude items
+    const mark = markVisible(makeFilter({ url: "-" }));
+    expect(mark(makeItem({ url: "https://example.com" })).$$visible).toBe(false);
+    expect(mark(makeItem({ url: "some-hyphen-url" })).$$visible).toBe(true);
+  });
+
+  it("handles numeric field values (e.g. status as number)", () => {
+    const mark = markVisible(makeFilter({ status: "200" }));
+    expect(mark(makeItem({ status: 200 })).$$visible).toBe(true);
+    expect(mark(makeItem({ status: 404 })).$$visible).toBe(false);
+  });
+
+  it("marks item visible when a negative token is combined with a matching positive token", () => {
+    const mark = markVisible(makeFilter({ url: "example -posts" }));
+    expect(mark(makeItem({ url: "https://example.com/api/users" })).$$visible).toBe(true);
+    expect(mark(makeItem({ url: "https://example.com/api/posts" })).$$visible).toBe(false);
+  });
+
+  it("marks item visible for undefined field value against negative token", () => {
+    const mark = markVisible(makeFilter({ url: "-missing" }));
+    expect(mark(makeItem({ url: undefined })).$$visible).toBe(true);
+  });
+
+  it("preserves all other fields on the returned ListItem", () => {
+    const item = makeItem({ $$id: 7, $$visible: false, $$hidden: false, startedDateTime: "t", time: 99, pageref: "p1", statusText: "OK" });
+    const result = markVisible(makeFilter())(item);
+    expect(result.$$id).toBe(7);
+    expect(result.startedDateTime).toBe("t");
+    expect(result.time).toBe(99);
+  });
 });


### PR DESCRIPTION
## Summary
- Adds edge-case tests for `markVisible` in `filter.test.ts`: case-insensitive matching, bare `-` token (positive match), numeric field coercion, mixed positive/negative tokens, `undefined` field against negative token, field preservation on returned item
- Adds new `deriveTabData.test.ts` covering all four tab types (REQ/RES/COO/TIM), null entry, missing optional data (postData, content.text), empty cookie arrays, and zero totalTime
- Adds new `deriveListData.test.ts` covering null/non-array input, empty array, correct field mapping, sequential `$$id`, `$$visible`/`$$hidden` initialisation, undefined pageref, and multi-entry distinctness

Closes #72 (PR I — Finding 11 test coverage)

Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>