### PR TITLE
feat(web): add HTTP security headers

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -12,5 +12,28 @@ module.exports = {
     "@repo/plugin-user-agent-raw",
     "@repo/plugin-headers-plain",
   ],
-  output: "export",
+  async headers() {
+    return [
+      {
+        source: "/(.*)",
+        headers: [
+          { key: "X-Frame-Options", value: "DENY" },
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+          {
+            key: "Content-Security-Policy",
+            value: [
+              "default-src 'self'",
+              "script-src 'self' 'unsafe-inline'",
+              "style-src 'self' 'unsafe-inline'",
+              "img-src 'self' data:",
+              "font-src 'self'",
+              "connect-src 'self'",
+              "frame-ancestors 'none'",
+            ].join("; "),
+          },
+        ],
+      },
+    ];
+  },
 };


### PR DESCRIPTION
## Summary

- Adds `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy: strict-origin-when-cross-origin`, and `Content-Security-Policy` headers to all responses via `next.config.js`
- Removes `output: "export"` — required so the Next.js server can apply the headers (static export mode silently ignores the `headers()` function)

Closes #87

Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>