### PR TITLE
feat(timing): combined bar label, cross-highlight, and striped sub-segment

### DIFF
--- a/apps/web/app/features/detail/components/TimTab.tsx
+++ b/apps/web/app/features/detail/components/TimTab.tsx
@@ -1,8 +1,9 @@
 "use client";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import type React from "react";
 import type { TimTabData } from "../types";
 import { NoContent } from "@repo/ui/no-content";
+import { buildTimingSegments } from "../helpers/timingSpec";
 import { TimingBar } from "./TimingBar";
 import { TimingTable } from "./TimingTable";
 
@@ -10,9 +11,27 @@ export function TimTab({ data }: { data: TimTabData }): React.JSX.Element {
   const { timings, totalTime } = data;
   const [hoveredKey, setHoveredKey] = useState<string | null>(null);
 
+  const subToParent = useMemo<Record<string, string>>(() => {
+    if (!timings || !totalTime) return {};
+    const map: Record<string, string> = {};
+    for (const seg of buildTimingSegments(timings, totalTime)) {
+      if (seg.subSegment?.key) map[seg.subSegment.key] = seg.key;
+    }
+    return map;
+  }, [timings, totalTime]);
+
   if (!timings || !totalTime) {
     return <NoContent />;
   }
+
+  const barHoveredKey = hoveredKey ? (subToParent[hoveredKey] ?? hoveredKey) : null;
+  const tableHoveredKeys: string[] = hoveredKey
+    ? [
+        hoveredKey,
+        ...(subToParent[hoveredKey] ? [subToParent[hoveredKey]!] : []),
+        ...Object.entries(subToParent).filter(([, p]) => p === hoveredKey).map(([c]) => c),
+      ]
+    : [];
 
   return (
     <div className="space-y-4 p-2">
@@ -23,13 +42,13 @@ export function TimTab({ data }: { data: TimTabData }): React.JSX.Element {
       <TimingBar
         timings={timings}
         totalTime={totalTime}
-        hoveredKey={hoveredKey}
+        hoveredKey={barHoveredKey}
         onHover={setHoveredKey}
       />
       <TimingTable
         timings={timings}
         totalTime={totalTime}
-        hoveredKey={hoveredKey}
+        hoveredKeys={tableHoveredKeys}
         onHover={setHoveredKey}
       />
     </div>

--- a/apps/web/app/features/detail/components/TimingTable.tsx
+++ b/apps/web/app/features/detail/components/TimingTable.tsx
@@ -5,14 +5,14 @@ import { buildTimingRows } from "../helpers/timingSpec";
 export interface TimingTableProps {
   timings: Record<string, number>;
   totalTime: number;
-  hoveredKey?: string | null;
+  hoveredKeys?: string[];
   onHover?: (key: string | null) => void;
 }
 
 export function TimingTable({
   timings,
   totalTime,
-  hoveredKey,
+  hoveredKeys,
   onHover,
 }: TimingTableProps): React.JSX.Element {
   const rows = buildTimingRows(timings, totalTime);
@@ -20,7 +20,7 @@ export function TimingTable({
     <TimingTableUI
       rows={rows}
       totalTime={totalTime}
-      hoveredKey={hoveredKey}
+      hoveredKeys={hoveredKeys}
       onHover={onHover}
     />
   );

--- a/apps/web/app/features/detail/helpers/timingSpec.ts
+++ b/apps/web/app/features/detail/helpers/timingSpec.ts
@@ -3,6 +3,7 @@ export interface TimingFieldSpec {
   color: string;
   name: string;
   description: string;
+  parent?: string;
 }
 
 export const TIMING_SPEC: TimingFieldSpec[] = [
@@ -38,9 +39,10 @@ export const TIMING_SPEC: TimingFieldSpec[] = [
   },
   {
     key: "ssl",
-    color: "#c09038",
+    color: "#b87840",
     name: "SSL",
     description: "SSL/TLS handshake time (included within connect)",
+    parent: "connect",
   },
   {
     key: "send",
@@ -62,18 +64,16 @@ export const TIMING_SPEC: TimingFieldSpec[] = [
   },
 ];
 
-export const SSL_KEY = "ssl";
-export const CONNECT_KEY = "connect";
+const childSpecs = TIMING_SPEC.filter((s) => s.parent !== undefined);
 
 export function buildTimingSegments(
   timings: Record<string, number>,
   totalTime: number,
 ) {
-  const mainSpecs = TIMING_SPEC.filter((s) => s.key !== SSL_KEY);
-  const sslSpec = TIMING_SPEC.find((s) => s.key === SSL_KEY)!;
-  const sslValue = timings[SSL_KEY] ?? -1;
+  const childKeys = new Set(childSpecs.map((s) => s.key));
+  const parentSpecs = TIMING_SPEC.filter((s) => !childKeys.has(s.key));
 
-  const visible = mainSpecs
+  const visible = parentSpecs
     .map((s) => ({ ...s, value: timings[s.key] ?? -1 }))
     .filter((s) => s.value > 0);
 
@@ -89,16 +89,18 @@ export function buildTimingSegments(
     const leftPct = cumLeft;
     cumLeft += widthPct;
 
-    const isConnect = s.key === CONNECT_KEY;
+    const childSpec = childSpecs.find((c) => c.parent === s.key);
+    const childValue = childSpec ? (timings[childSpec.key] ?? -1) : -1;
     const subSegment =
-      isConnect && sslValue > 0
-        ? { color: sslSpec.color, widthPct: (sslValue / s.value) * 100 }
+      childSpec && childValue > 0
+        ? { key: childSpec.key, color: childSpec.color, widthPct: (childValue / s.value) * 100 }
         : undefined;
+    const name = subSegment ? `${s.name}/${childSpec!.name}` : s.name;
 
     return {
       key: s.key,
       color: s.color,
-      name: s.name,
+      name,
       value: s.value,
       pct: (s.value / totalTime) * 100,
       widthPct,
@@ -121,5 +123,6 @@ export function buildTimingRows(
       description: s.description,
       value: s.value,
       pct: (s.value / totalTime) * 100,
+      ...(s.parent !== undefined && { striped: true }),
     }));
 }

--- a/packages/ui/src/timing-bar.tsx
+++ b/packages/ui/src/timing-bar.tsx
@@ -11,6 +11,7 @@ export interface TimingSegment {
   widthPct: number;
   leftPct: number;
   subSegment?: {
+    key: string;
     color: string;
     widthPct: number;
   };
@@ -87,6 +88,9 @@ export function TimingBar({
             <clipPath id={`bar-${uid}`}>
               <rect x={0} y={barY} width={barW} height={BAR_H} rx={BAR_RADIUS} />
             </clipPath>
+            <pattern id={`stripe-${uid}`} patternUnits="userSpaceOnUse" width="6" height="6" patternTransform="rotate(45)">
+              <line x1="0" y1="0" x2="0" y2="6" stroke="rgba(255,255,255,0.4)" strokeWidth="3" />
+            </pattern>
           </defs>
 
           {/* Bar segments */}
@@ -101,15 +105,16 @@ export function TimingBar({
                   onMouseLeave={() => onHover?.(null)}
                 >
                   <rect x={seg.x} y={barY} width={seg.w} height={BAR_H} fill={seg.color} />
-                  {seg.subSegment && (
-                    <rect
-                      x={seg.x + seg.w - (seg.subSegment.widthPct / 100) * seg.w}
-                      y={barY}
-                      width={(seg.subSegment.widthPct / 100) * seg.w}
-                      height={BAR_H}
-                      fill={seg.subSegment.color}
-                    />
-                  )}
+                  {seg.subSegment && (() => {
+                    const subX = seg.x + seg.w - (seg.subSegment.widthPct / 100) * seg.w;
+                    const subW = (seg.subSegment.widthPct / 100) * seg.w;
+                    return (
+                      <>
+                        <rect x={subX} y={barY} width={subW} height={BAR_H} fill={seg.subSegment.color} />
+                        <rect x={subX} y={barY} width={subW} height={BAR_H} fill={`url(#stripe-${uid})`} />
+                      </>
+                    );
+                  })()}
                 </g>
               );
             })}

--- a/packages/ui/src/timing-table.test.tsx
+++ b/packages/ui/src/timing-table.test.tsx
@@ -5,7 +5,8 @@ import type { TimingRow } from "./timing-table";
 
 const rows: TimingRow[] = [
   { key: "dns", color: "#4caf50", name: "DNS", description: "DNS lookup", value: 12.5, pct: 25 },
-  { key: "connect", color: "#2196f3", name: "Connect", description: "TCP connect", value: 10.0, pct: 20 },
+  { key: "connect", color: "#2196f3", name: "Connect/SSL", description: "TCP connect", value: 10.0, pct: 20 },
+  { key: "ssl", color: "#c09038", name: "SSL", description: "SSL handshake", value: 5.0, pct: 10 },
 ];
 
 describe("TimingTable", () => {
@@ -17,7 +18,7 @@ describe("TimingTable", () => {
   it("renders row names", () => {
     render(<TimingTable rows={rows} totalTime={50} />);
     expect(screen.getByText("DNS")).toBeInTheDocument();
-    expect(screen.getByText("Connect")).toBeInTheDocument();
+    expect(screen.getByText("Connect/SSL")).toBeInTheDocument();
   });
 
   it("renders row descriptions", () => {
@@ -59,8 +60,24 @@ describe("TimingTable", () => {
   });
 
   it("highlights hovered row", () => {
-    render(<TimingTable rows={rows} totalTime={50} hoveredKey="dns" />);
+    render(<TimingTable rows={rows} totalTime={50} hoveredKeys={["dns"]} />);
     const dnsRow = screen.getByText("DNS").closest("tr");
     expect(dnsRow).toHaveStyle("background-color: rgba(0,0,0,0.06)");
+  });
+
+  it("highlights both sub-segment and parent row when hoveredKeys includes both", () => {
+    render(<TimingTable rows={rows} totalTime={50} hoveredKeys={["ssl", "connect"]} />);
+    const connectRow = screen.getByText("Connect/SSL").closest("tr");
+    const sslRow = screen.getByText("SSL").closest("tr");
+    expect(connectRow).toHaveStyle("background-color: rgba(0,0,0,0.06)");
+    expect(sslRow).toHaveStyle("background-color: rgba(0,0,0,0.06)");
+  });
+
+  it("highlights both parent and child row when hoveredKeys includes both", () => {
+    render(<TimingTable rows={rows} totalTime={50} hoveredKeys={["connect", "ssl"]} />);
+    const connectRow = screen.getByText("Connect/SSL").closest("tr");
+    const sslRow = screen.getByText("SSL").closest("tr");
+    expect(connectRow).toHaveStyle("background-color: rgba(0,0,0,0.06)");
+    expect(sslRow).toHaveStyle("background-color: rgba(0,0,0,0.06)");
   });
 });

--- a/packages/ui/src/timing-table.tsx
+++ b/packages/ui/src/timing-table.tsx
@@ -7,19 +7,20 @@ export interface TimingRow {
   description: string;
   value: number;
   pct: number;
+  striped?: boolean;
 }
 
 export interface TimingTableProps {
   rows: TimingRow[];
   totalTime: number;
-  hoveredKey?: string | null;
+  hoveredKeys?: string[];
   onHover?: (key: string | null) => void;
 }
 
 export function TimingTable({
   rows,
   totalTime,
-  hoveredKey,
+  hoveredKeys,
   onHover,
 }: TimingTableProps): React.JSX.Element {
   return (
@@ -35,7 +36,7 @@ export function TimingTable({
       </thead>
       <tbody>
         {rows.map((row) => {
-          const isHovered = hoveredKey === row.key;
+          const isHovered = hoveredKeys?.includes(row.key) ?? false;
           const white = isHovered ? "white" : undefined;
           return (
             <tr
@@ -48,7 +49,14 @@ export function TimingTable({
               <td className="py-1 pr-2 align-middle">
                 <div
                   className="rounded-sm transition-colors duration-200"
-                  style={{ width: 12, height: 12, backgroundColor: row.color }}
+                  style={{
+                    width: 12,
+                    height: 12,
+                    backgroundColor: row.color,
+                    ...(row.striped && {
+                      backgroundImage: "repeating-linear-gradient(-45deg, rgba(255,255,255,0.4) 0px, rgba(255,255,255,0.4) 2px, transparent 2px, transparent 5px)",
+                    }),
+                  }}
                 />
               </td>
               <td


### PR DESCRIPTION
## Summary

- Add `parent` field to `TimingFieldSpec` for declarative child-parent bonding — removes hardcoded `SSL_KEY`/`CONNECT_KEY` constants
- Bar label for a parent segment with a child displays a combined name (e.g. **Connect/SSL**)
- Sub-segment in the bar is rendered with a diagonal stripe overlay on the shared parent color
- Table color swatch for child rows shows matching diagonal stripes
- Hovering a sub-segment row highlights both the child and parent rows (and vice versa)
- `hoveredKey` → `hoveredKeys: string[]` in timing table to support multi-row highlight
- Bidirectional hover wiring in `TimTab` via a `subToParent` map

Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>